### PR TITLE
feat(customer): Customer CRUD + duplicate detection (#4)

### DIFF
--- a/apps/octattoo/octattoo_client/lib/src/protocol/artist_profile/artist_profile.dart
+++ b/apps/octattoo/octattoo_client/lib/src/protocol/artist_profile/artist_profile.dart
@@ -1,0 +1,104 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+
+/// An artist's brand identity, auto-created on account registration.
+abstract class ArtistProfile implements _i1.SerializableModel {
+  ArtistProfile._({
+    this.id,
+    required this.authUserId,
+    required this.name,
+  });
+
+  factory ArtistProfile({
+    _i1.UuidValue? id,
+    required _i1.UuidValue authUserId,
+    required String name,
+  }) = _ArtistProfileImpl;
+
+  factory ArtistProfile.fromJson(Map<String, dynamic> jsonSerialization) {
+    return ArtistProfile(
+      id: jsonSerialization['id'] == null
+          ? null
+          : _i1.UuidValueJsonExtension.fromJson(jsonSerialization['id']),
+      authUserId: _i1.UuidValueJsonExtension.fromJson(
+        jsonSerialization['authUserId'],
+      ),
+      name: jsonSerialization['name'] as String,
+    );
+  }
+
+  /// The database id, set if the object has been inserted into the
+  /// database or if it has been fetched from the database. Otherwise,
+  /// the id will be null.
+  _i1.UuidValue? id;
+
+  /// The auth user this profile belongs to.
+  _i1.UuidValue authUserId;
+
+  /// Display name for the artist.
+  String name;
+
+  /// Returns a shallow copy of this [ArtistProfile]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  ArtistProfile copyWith({
+    _i1.UuidValue? id,
+    _i1.UuidValue? authUserId,
+    String? name,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      '__className__': 'ArtistProfile',
+      if (id != null) 'id': id?.toJson(),
+      'authUserId': authUserId.toJson(),
+      'name': name,
+    };
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _Undefined {}
+
+class _ArtistProfileImpl extends ArtistProfile {
+  _ArtistProfileImpl({
+    _i1.UuidValue? id,
+    required _i1.UuidValue authUserId,
+    required String name,
+  }) : super._(
+         id: id,
+         authUserId: authUserId,
+         name: name,
+       );
+
+  /// Returns a shallow copy of this [ArtistProfile]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  ArtistProfile copyWith({
+    Object? id = _Undefined,
+    _i1.UuidValue? authUserId,
+    String? name,
+  }) {
+    return ArtistProfile(
+      id: id is _i1.UuidValue? ? id : this.id,
+      authUserId: authUserId ?? this.authUserId,
+      name: name ?? this.name,
+    );
+  }
+}

--- a/apps/octattoo/octattoo_client/lib/src/protocol/client.dart
+++ b/apps/octattoo/octattoo_client/lib/src/protocol/client.dart
@@ -16,8 +16,11 @@ import 'package:serverpod_auth_idp_client/serverpod_auth_idp_client.dart'
     as _i3;
 import 'package:serverpod_auth_core_client/serverpod_auth_core_client.dart'
     as _i4;
-import 'package:octattoo_client/src/protocol/greetings/greeting.dart' as _i5;
-import 'protocol.dart' as _i6;
+import 'package:octattoo_client/src/protocol/customer/create_customer_result.dart'
+    as _i5;
+import 'package:octattoo_client/src/protocol/customer/customer.dart' as _i6;
+import 'package:octattoo_client/src/protocol/greetings/greeting.dart' as _i7;
+import 'protocol.dart' as _i8;
 
 /// {@category Endpoint}
 class EndpointArtistProfile extends _i1.EndpointRef {
@@ -257,6 +260,74 @@ class EndpointJwtRefresh extends _i4.EndpointRefreshJwtTokens {
   );
 }
 
+/// {@category Endpoint}
+class EndpointCustomer extends _i1.EndpointRef {
+  EndpointCustomer(_i1.EndpointCaller caller) : super(caller);
+
+  @override
+  String get name => 'customer';
+
+  /// Creates a customer, returning potential duplicates.
+  _i2.Future<_i5.CreateCustomerResult> createCustomer({
+    required String name,
+    String? email,
+    String? phone,
+    String? notes,
+  }) => caller.callServerEndpoint<_i5.CreateCustomerResult>(
+    'customer',
+    'createCustomer',
+    {
+      'name': name,
+      'email': email,
+      'phone': phone,
+      'notes': notes,
+    },
+  );
+
+  /// Lists customers for the current artist profile.
+  _i2.Future<List<_i6.Customer>> listCustomers({String? search}) =>
+      caller.callServerEndpoint<List<_i6.Customer>>(
+        'customer',
+        'listCustomers',
+        {'search': search},
+      );
+
+  /// Gets a single customer by ID (scoped to artist profile).
+  _i2.Future<_i6.Customer?> getCustomer(_i1.UuidValue customerId) =>
+      caller.callServerEndpoint<_i6.Customer?>(
+        'customer',
+        'getCustomer',
+        {'customerId': customerId},
+      );
+
+  /// Updates a customer (scoped to artist profile).
+  _i2.Future<_i6.Customer?> updateCustomer({
+    required _i1.UuidValue customerId,
+    required String name,
+    String? email,
+    String? phone,
+    String? notes,
+  }) => caller.callServerEndpoint<_i6.Customer?>(
+    'customer',
+    'updateCustomer',
+    {
+      'customerId': customerId,
+      'name': name,
+      'email': email,
+      'phone': phone,
+      'notes': notes,
+    },
+  );
+
+  /// Deletes a customer (scoped to artist profile).
+  _i2.Future<bool> deleteCustomer(_i1.UuidValue customerId) =>
+      caller.callServerEndpoint<bool>(
+        'customer',
+        'deleteCustomer',
+        {'customerId': customerId},
+      );
+}
+
 /// This is an example endpoint that returns a greeting message through
 /// its [hello] method.
 /// {@category Endpoint}
@@ -267,8 +338,8 @@ class EndpointGreeting extends _i1.EndpointRef {
   String get name => 'greeting';
 
   /// Returns a personalized greeting message: "Hello {name}".
-  _i2.Future<_i5.Greeting> hello(String name) =>
-      caller.callServerEndpoint<_i5.Greeting>(
+  _i2.Future<_i7.Greeting> hello(String name) =>
+      caller.callServerEndpoint<_i7.Greeting>(
         'greeting',
         'hello',
         {'name': name},
@@ -306,7 +377,7 @@ class Client extends _i1.ServerpodClientShared {
     bool? disconnectStreamsOnLostInternetConnection,
   }) : super(
          host,
-         _i6.Protocol(),
+         _i8.Protocol(),
          securityContext: securityContext,
          streamingConnectionTimeout: streamingConnectionTimeout,
          connectionTimeout: connectionTimeout,
@@ -318,6 +389,7 @@ class Client extends _i1.ServerpodClientShared {
     artistProfile = EndpointArtistProfile(this);
     emailIdp = EndpointEmailIdp(this);
     jwtRefresh = EndpointJwtRefresh(this);
+    customer = EndpointCustomer(this);
     greeting = EndpointGreeting(this);
     modules = Modules(this);
   }
@@ -328,6 +400,8 @@ class Client extends _i1.ServerpodClientShared {
 
   late final EndpointJwtRefresh jwtRefresh;
 
+  late final EndpointCustomer customer;
+
   late final EndpointGreeting greeting;
 
   late final Modules modules;
@@ -337,6 +411,7 @@ class Client extends _i1.ServerpodClientShared {
     'artistProfile': artistProfile,
     'emailIdp': emailIdp,
     'jwtRefresh': jwtRefresh,
+    'customer': customer,
     'greeting': greeting,
   };
 

--- a/apps/octattoo/octattoo_client/lib/src/protocol/client.dart
+++ b/apps/octattoo/octattoo_client/lib/src/protocol/client.dart
@@ -10,21 +10,38 @@
 // ignore_for_file: invalid_use_of_internal_member
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'dart:async' as _i2;
 import 'package:serverpod_auth_idp_client/serverpod_auth_idp_client.dart'
-    as _i1;
-import 'package:serverpod_client/serverpod_client.dart' as _i2;
-import 'dart:async' as _i3;
+    as _i3;
 import 'package:serverpod_auth_core_client/serverpod_auth_core_client.dart'
     as _i4;
 import 'package:octattoo_client/src/protocol/greetings/greeting.dart' as _i5;
 import 'protocol.dart' as _i6;
 
+/// {@category Endpoint}
+class EndpointArtistProfile extends _i1.EndpointRef {
+  EndpointArtistProfile(_i1.EndpointCaller caller) : super(caller);
+
+  @override
+  String get name => 'artistProfile';
+
+  /// Returns the current user's artist profile ID.
+  /// Auto-creates the profile on first call.
+  _i2.Future<_i1.UuidValue> getMyProfileId() =>
+      caller.callServerEndpoint<_i1.UuidValue>(
+        'artistProfile',
+        'getMyProfileId',
+        {},
+      );
+}
+
 /// By extending [EmailIdpBaseEndpoint], the email identity provider endpoints
 /// are made available on the server and enable the corresponding sign-in widget
 /// on the client.
 /// {@category Endpoint}
-class EndpointEmailIdp extends _i1.EndpointEmailIdpBase {
-  EndpointEmailIdp(_i2.EndpointCaller caller) : super(caller);
+class EndpointEmailIdp extends _i3.EndpointEmailIdpBase {
+  EndpointEmailIdp(_i1.EndpointCaller caller) : super(caller);
 
   @override
   String get name => 'emailIdp';
@@ -39,7 +56,7 @@ class EndpointEmailIdp extends _i1.EndpointEmailIdpBase {
   ///
   /// Throws an [AuthUserBlockedException] if the auth user is blocked.
   @override
-  _i3.Future<_i4.AuthSuccess> login({
+  _i2.Future<_i4.AuthSuccess> login({
     required String email,
     required String password,
   }) => caller.callServerEndpoint<_i4.AuthSuccess>(
@@ -62,8 +79,8 @@ class EndpointEmailIdp extends _i1.EndpointEmailIdpBase {
   /// registration. If the email is already registered, the returned ID will not
   /// be valid.
   @override
-  _i3.Future<_i2.UuidValue> startRegistration({required String email}) =>
-      caller.callServerEndpoint<_i2.UuidValue>(
+  _i2.Future<_i1.UuidValue> startRegistration({required String email}) =>
+      caller.callServerEndpoint<_i1.UuidValue>(
         'emailIdp',
         'startRegistration',
         {'email': email},
@@ -80,8 +97,8 @@ class EndpointEmailIdp extends _i1.EndpointEmailIdpBase {
   /// - [EmailAccountRequestExceptionReason.invalid] if no request exists
   ///   for the given [accountRequestId] or [verificationCode] is invalid.
   @override
-  _i3.Future<String> verifyRegistrationCode({
-    required _i2.UuidValue accountRequestId,
+  _i2.Future<String> verifyRegistrationCode({
+    required _i1.UuidValue accountRequestId,
     required String verificationCode,
   }) => caller.callServerEndpoint<String>(
     'emailIdp',
@@ -107,7 +124,7 @@ class EndpointEmailIdp extends _i1.EndpointEmailIdpBase {
   ///
   /// Returns a session for the newly created user.
   @override
-  _i3.Future<_i4.AuthSuccess> finishRegistration({
+  _i2.Future<_i4.AuthSuccess> finishRegistration({
     required String registrationToken,
     required String password,
   }) => caller.callServerEndpoint<_i4.AuthSuccess>(
@@ -133,8 +150,8 @@ class EndpointEmailIdp extends _i1.EndpointEmailIdpBase {
   ///   made too many attempts trying to request a password reset.
   ///
   @override
-  _i3.Future<_i2.UuidValue> startPasswordReset({required String email}) =>
-      caller.callServerEndpoint<_i2.UuidValue>(
+  _i2.Future<_i1.UuidValue> startPasswordReset({required String email}) =>
+      caller.callServerEndpoint<_i1.UuidValue>(
         'emailIdp',
         'startPasswordReset',
         {'email': email},
@@ -155,8 +172,8 @@ class EndpointEmailIdp extends _i1.EndpointEmailIdpBase {
   /// should be overridden to return credentials for the next step instead
   /// of the credentials for setting the password.
   @override
-  _i3.Future<String> verifyPasswordResetCode({
-    required _i2.UuidValue passwordResetRequestId,
+  _i2.Future<String> verifyPasswordResetCode({
+    required _i1.UuidValue passwordResetRequestId,
     required String verificationCode,
   }) => caller.callServerEndpoint<String>(
     'emailIdp',
@@ -182,7 +199,7 @@ class EndpointEmailIdp extends _i1.EndpointEmailIdpBase {
   ///
   /// Throws an [AuthUserBlockedException] if the auth user is blocked.
   @override
-  _i3.Future<void> finishPasswordReset({
+  _i2.Future<void> finishPasswordReset({
     required String finishPasswordResetToken,
     required String newPassword,
   }) => caller.callServerEndpoint<void>(
@@ -195,7 +212,7 @@ class EndpointEmailIdp extends _i1.EndpointEmailIdpBase {
   );
 
   @override
-  _i3.Future<bool> hasAccount() => caller.callServerEndpoint<bool>(
+  _i2.Future<bool> hasAccount() => caller.callServerEndpoint<bool>(
     'emailIdp',
     'hasAccount',
     {},
@@ -206,7 +223,7 @@ class EndpointEmailIdp extends _i1.EndpointEmailIdpBase {
 /// is made available on the server and enables automatic token refresh on the client.
 /// {@category Endpoint}
 class EndpointJwtRefresh extends _i4.EndpointRefreshJwtTokens {
-  EndpointJwtRefresh(_i2.EndpointCaller caller) : super(caller);
+  EndpointJwtRefresh(_i1.EndpointCaller caller) : super(caller);
 
   @override
   String get name => 'jwtRefresh';
@@ -230,7 +247,7 @@ class EndpointJwtRefresh extends _i4.EndpointRefreshJwtTokens {
   /// This endpoint is unauthenticated, meaning the client won't include any
   /// authentication information with the call.
   @override
-  _i3.Future<_i4.AuthSuccess> refreshAccessToken({
+  _i2.Future<_i4.AuthSuccess> refreshAccessToken({
     required String refreshToken,
   }) => caller.callServerEndpoint<_i4.AuthSuccess>(
     'jwtRefresh',
@@ -243,14 +260,14 @@ class EndpointJwtRefresh extends _i4.EndpointRefreshJwtTokens {
 /// This is an example endpoint that returns a greeting message through
 /// its [hello] method.
 /// {@category Endpoint}
-class EndpointGreeting extends _i2.EndpointRef {
-  EndpointGreeting(_i2.EndpointCaller caller) : super(caller);
+class EndpointGreeting extends _i1.EndpointRef {
+  EndpointGreeting(_i1.EndpointCaller caller) : super(caller);
 
   @override
   String get name => 'greeting';
 
   /// Returns a personalized greeting message: "Hello {name}".
-  _i3.Future<_i5.Greeting> hello(String name) =>
+  _i2.Future<_i5.Greeting> hello(String name) =>
       caller.callServerEndpoint<_i5.Greeting>(
         'greeting',
         'hello',
@@ -260,16 +277,16 @@ class EndpointGreeting extends _i2.EndpointRef {
 
 class Modules {
   Modules(Client client) {
-    serverpod_auth_idp = _i1.Caller(client);
+    serverpod_auth_idp = _i3.Caller(client);
     serverpod_auth_core = _i4.Caller(client);
   }
 
-  late final _i1.Caller serverpod_auth_idp;
+  late final _i3.Caller serverpod_auth_idp;
 
   late final _i4.Caller serverpod_auth_core;
 }
 
-class Client extends _i2.ServerpodClientShared {
+class Client extends _i1.ServerpodClientShared {
   Client(
     String host, {
     dynamic securityContext,
@@ -280,12 +297,12 @@ class Client extends _i2.ServerpodClientShared {
     Duration? streamingConnectionTimeout,
     Duration? connectionTimeout,
     Function(
-      _i2.MethodCallContext,
+      _i1.MethodCallContext,
       Object,
       StackTrace,
     )?
     onFailedCall,
-    Function(_i2.MethodCallContext)? onSucceededCall,
+    Function(_i1.MethodCallContext)? onSucceededCall,
     bool? disconnectStreamsOnLostInternetConnection,
   }) : super(
          host,
@@ -298,11 +315,14 @@ class Client extends _i2.ServerpodClientShared {
          disconnectStreamsOnLostInternetConnection:
              disconnectStreamsOnLostInternetConnection,
        ) {
+    artistProfile = EndpointArtistProfile(this);
     emailIdp = EndpointEmailIdp(this);
     jwtRefresh = EndpointJwtRefresh(this);
     greeting = EndpointGreeting(this);
     modules = Modules(this);
   }
+
+  late final EndpointArtistProfile artistProfile;
 
   late final EndpointEmailIdp emailIdp;
 
@@ -313,14 +333,15 @@ class Client extends _i2.ServerpodClientShared {
   late final Modules modules;
 
   @override
-  Map<String, _i2.EndpointRef> get endpointRefLookup => {
+  Map<String, _i1.EndpointRef> get endpointRefLookup => {
+    'artistProfile': artistProfile,
     'emailIdp': emailIdp,
     'jwtRefresh': jwtRefresh,
     'greeting': greeting,
   };
 
   @override
-  Map<String, _i2.ModuleEndpointCaller> get moduleLookup => {
+  Map<String, _i1.ModuleEndpointCaller> get moduleLookup => {
     'serverpod_auth_idp': modules.serverpod_auth_idp,
     'serverpod_auth_core': modules.serverpod_auth_core,
   };

--- a/apps/octattoo/octattoo_client/lib/src/protocol/customer/create_customer_result.dart
+++ b/apps/octattoo/octattoo_client/lib/src/protocol/customer/create_customer_result.dart
@@ -1,0 +1,96 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import '../customer/customer.dart' as _i2;
+import 'package:octattoo_client/src/protocol/protocol.dart' as _i3;
+
+/// Result of creating a customer, includes potential duplicates.
+abstract class CreateCustomerResult implements _i1.SerializableModel {
+  CreateCustomerResult._({
+    required this.customer,
+    required this.potentialDuplicates,
+  });
+
+  factory CreateCustomerResult({
+    required _i2.Customer customer,
+    required List<_i2.Customer> potentialDuplicates,
+  }) = _CreateCustomerResultImpl;
+
+  factory CreateCustomerResult.fromJson(
+    Map<String, dynamic> jsonSerialization,
+  ) {
+    return CreateCustomerResult(
+      customer: _i3.Protocol().deserialize<_i2.Customer>(
+        jsonSerialization['customer'],
+      ),
+      potentialDuplicates: _i3.Protocol().deserialize<List<_i2.Customer>>(
+        jsonSerialization['potentialDuplicates'],
+      ),
+    );
+  }
+
+  /// The newly created customer.
+  _i2.Customer customer;
+
+  /// Potential duplicate customers (non-blocking).
+  List<_i2.Customer> potentialDuplicates;
+
+  /// Returns a shallow copy of this [CreateCustomerResult]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  CreateCustomerResult copyWith({
+    _i2.Customer? customer,
+    List<_i2.Customer>? potentialDuplicates,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      '__className__': 'CreateCustomerResult',
+      'customer': customer.toJson(),
+      'potentialDuplicates': potentialDuplicates.toJson(
+        valueToJson: (v) => v.toJson(),
+      ),
+    };
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _CreateCustomerResultImpl extends CreateCustomerResult {
+  _CreateCustomerResultImpl({
+    required _i2.Customer customer,
+    required List<_i2.Customer> potentialDuplicates,
+  }) : super._(
+         customer: customer,
+         potentialDuplicates: potentialDuplicates,
+       );
+
+  /// Returns a shallow copy of this [CreateCustomerResult]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  CreateCustomerResult copyWith({
+    _i2.Customer? customer,
+    List<_i2.Customer>? potentialDuplicates,
+  }) {
+    return CreateCustomerResult(
+      customer: customer ?? this.customer.copyWith(),
+      potentialDuplicates:
+          potentialDuplicates ??
+          this.potentialDuplicates.map((e0) => e0.copyWith()).toList(),
+    );
+  }
+}

--- a/apps/octattoo/octattoo_client/lib/src/protocol/customer/customer.dart
+++ b/apps/octattoo/octattoo_client/lib/src/protocol/customer/customer.dart
@@ -1,0 +1,154 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+
+/// A person who receives tattoos. Scoped to a single Artist Profile.
+abstract class Customer implements _i1.SerializableModel {
+  Customer._({
+    this.id,
+    required this.artistProfileId,
+    required this.name,
+    this.email,
+    this.phone,
+    this.notes,
+    this.createdAt,
+  });
+
+  factory Customer({
+    _i1.UuidValue? id,
+    required _i1.UuidValue artistProfileId,
+    required String name,
+    String? email,
+    String? phone,
+    String? notes,
+    DateTime? createdAt,
+  }) = _CustomerImpl;
+
+  factory Customer.fromJson(Map<String, dynamic> jsonSerialization) {
+    return Customer(
+      id: jsonSerialization['id'] == null
+          ? null
+          : _i1.UuidValueJsonExtension.fromJson(jsonSerialization['id']),
+      artistProfileId: _i1.UuidValueJsonExtension.fromJson(
+        jsonSerialization['artistProfileId'],
+      ),
+      name: jsonSerialization['name'] as String,
+      email: jsonSerialization['email'] as String?,
+      phone: jsonSerialization['phone'] as String?,
+      notes: jsonSerialization['notes'] as String?,
+      createdAt: jsonSerialization['createdAt'] == null
+          ? null
+          : _i1.DateTimeJsonExtension.fromJson(jsonSerialization['createdAt']),
+    );
+  }
+
+  /// The database id, set if the object has been inserted into the
+  /// database or if it has been fetched from the database. Otherwise,
+  /// the id will be null.
+  _i1.UuidValue? id;
+
+  /// The artist profile this customer belongs to.
+  _i1.UuidValue artistProfileId;
+
+  /// Display name.
+  String name;
+
+  /// Contact email (at least one of email/phone required).
+  String? email;
+
+  /// Contact phone (at least one of email/phone required).
+  String? phone;
+
+  /// Free-form notes.
+  String? notes;
+
+  /// When this customer was created.
+  DateTime? createdAt;
+
+  /// Returns a shallow copy of this [Customer]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  Customer copyWith({
+    _i1.UuidValue? id,
+    _i1.UuidValue? artistProfileId,
+    String? name,
+    String? email,
+    String? phone,
+    String? notes,
+    DateTime? createdAt,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      '__className__': 'Customer',
+      if (id != null) 'id': id?.toJson(),
+      'artistProfileId': artistProfileId.toJson(),
+      'name': name,
+      if (email != null) 'email': email,
+      if (phone != null) 'phone': phone,
+      if (notes != null) 'notes': notes,
+      if (createdAt != null) 'createdAt': createdAt?.toJson(),
+    };
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _Undefined {}
+
+class _CustomerImpl extends Customer {
+  _CustomerImpl({
+    _i1.UuidValue? id,
+    required _i1.UuidValue artistProfileId,
+    required String name,
+    String? email,
+    String? phone,
+    String? notes,
+    DateTime? createdAt,
+  }) : super._(
+         id: id,
+         artistProfileId: artistProfileId,
+         name: name,
+         email: email,
+         phone: phone,
+         notes: notes,
+         createdAt: createdAt,
+       );
+
+  /// Returns a shallow copy of this [Customer]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  Customer copyWith({
+    Object? id = _Undefined,
+    _i1.UuidValue? artistProfileId,
+    String? name,
+    Object? email = _Undefined,
+    Object? phone = _Undefined,
+    Object? notes = _Undefined,
+    Object? createdAt = _Undefined,
+  }) {
+    return Customer(
+      id: id is _i1.UuidValue? ? id : this.id,
+      artistProfileId: artistProfileId ?? this.artistProfileId,
+      name: name ?? this.name,
+      email: email is String? ? email : this.email,
+      phone: phone is String? ? phone : this.phone,
+      notes: notes is String? ? notes : this.notes,
+      createdAt: createdAt is DateTime? ? createdAt : this.createdAt,
+    );
+  }
+}

--- a/apps/octattoo/octattoo_client/lib/src/protocol/protocol.dart
+++ b/apps/octattoo/octattoo_client/lib/src/protocol/protocol.dart
@@ -12,12 +12,17 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'artist_profile/artist_profile.dart' as _i2;
-import 'greetings/greeting.dart' as _i3;
+import 'customer/create_customer_result.dart' as _i3;
+import 'customer/customer.dart' as _i4;
+import 'greetings/greeting.dart' as _i5;
+import 'package:octattoo_client/src/protocol/customer/customer.dart' as _i6;
 import 'package:serverpod_auth_idp_client/serverpod_auth_idp_client.dart'
-    as _i4;
+    as _i7;
 import 'package:serverpod_auth_core_client/serverpod_auth_core_client.dart'
-    as _i5;
+    as _i8;
 export 'artist_profile/artist_profile.dart';
+export 'customer/create_customer_result.dart';
+export 'customer/customer.dart';
 export 'greetings/greeting.dart';
 export 'client.dart';
 
@@ -58,20 +63,41 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i2.ArtistProfile) {
       return _i2.ArtistProfile.fromJson(data) as T;
     }
-    if (t == _i3.Greeting) {
-      return _i3.Greeting.fromJson(data) as T;
+    if (t == _i3.CreateCustomerResult) {
+      return _i3.CreateCustomerResult.fromJson(data) as T;
+    }
+    if (t == _i4.Customer) {
+      return _i4.Customer.fromJson(data) as T;
+    }
+    if (t == _i5.Greeting) {
+      return _i5.Greeting.fromJson(data) as T;
     }
     if (t == _i1.getType<_i2.ArtistProfile?>()) {
       return (data != null ? _i2.ArtistProfile.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i3.Greeting?>()) {
-      return (data != null ? _i3.Greeting.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i3.CreateCustomerResult?>()) {
+      return (data != null ? _i3.CreateCustomerResult.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i4.Customer?>()) {
+      return (data != null ? _i4.Customer.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i5.Greeting?>()) {
+      return (data != null ? _i5.Greeting.fromJson(data) : null) as T;
+    }
+    if (t == List<_i4.Customer>) {
+      return (data as List).map((e) => deserialize<_i4.Customer>(e)).toList()
+          as T;
+    }
+    if (t == List<_i6.Customer>) {
+      return (data as List).map((e) => deserialize<_i6.Customer>(e)).toList()
+          as T;
     }
     try {
-      return _i4.Protocol().deserialize<T>(data, t);
+      return _i7.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     try {
-      return _i5.Protocol().deserialize<T>(data, t);
+      return _i8.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     return super.deserialize<T>(data, t);
   }
@@ -79,7 +105,9 @@ class Protocol extends _i1.SerializationManager {
   static String? getClassNameForType(Type type) {
     return switch (type) {
       _i2.ArtistProfile => 'ArtistProfile',
-      _i3.Greeting => 'Greeting',
+      _i3.CreateCustomerResult => 'CreateCustomerResult',
+      _i4.Customer => 'Customer',
+      _i5.Greeting => 'Greeting',
       _ => null,
     };
   }
@@ -96,14 +124,18 @@ class Protocol extends _i1.SerializationManager {
     switch (data) {
       case _i2.ArtistProfile():
         return 'ArtistProfile';
-      case _i3.Greeting():
+      case _i3.CreateCustomerResult():
+        return 'CreateCustomerResult';
+      case _i4.Customer():
+        return 'Customer';
+      case _i5.Greeting():
         return 'Greeting';
     }
-    className = _i4.Protocol().getClassNameForObject(data);
+    className = _i7.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth_idp.$className';
     }
-    className = _i5.Protocol().getClassNameForObject(data);
+    className = _i8.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth_core.$className';
     }
@@ -119,16 +151,22 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName == 'ArtistProfile') {
       return deserialize<_i2.ArtistProfile>(data['data']);
     }
+    if (dataClassName == 'CreateCustomerResult') {
+      return deserialize<_i3.CreateCustomerResult>(data['data']);
+    }
+    if (dataClassName == 'Customer') {
+      return deserialize<_i4.Customer>(data['data']);
+    }
     if (dataClassName == 'Greeting') {
-      return deserialize<_i3.Greeting>(data['data']);
+      return deserialize<_i5.Greeting>(data['data']);
     }
     if (dataClassName.startsWith('serverpod_auth_idp.')) {
       data['className'] = dataClassName.substring(19);
-      return _i4.Protocol().deserializeByClassName(data);
+      return _i7.Protocol().deserializeByClassName(data);
     }
     if (dataClassName.startsWith('serverpod_auth_core.')) {
       data['className'] = dataClassName.substring(20);
-      return _i5.Protocol().deserializeByClassName(data);
+      return _i8.Protocol().deserializeByClassName(data);
     }
     return super.deserializeByClassName(data);
   }
@@ -143,10 +181,10 @@ class Protocol extends _i1.SerializationManager {
       return null;
     }
     try {
-      return _i4.Protocol().mapRecordToJson(record);
+      return _i7.Protocol().mapRecordToJson(record);
     } catch (_) {}
     try {
-      return _i5.Protocol().mapRecordToJson(record);
+      return _i8.Protocol().mapRecordToJson(record);
     } catch (_) {}
     throw Exception('Unsupported record type ${record.runtimeType}');
   }

--- a/apps/octattoo/octattoo_client/lib/src/protocol/protocol.dart
+++ b/apps/octattoo/octattoo_client/lib/src/protocol/protocol.dart
@@ -11,11 +11,13 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'greetings/greeting.dart' as _i2;
+import 'artist_profile/artist_profile.dart' as _i2;
+import 'greetings/greeting.dart' as _i3;
 import 'package:serverpod_auth_idp_client/serverpod_auth_idp_client.dart'
-    as _i3;
-import 'package:serverpod_auth_core_client/serverpod_auth_core_client.dart'
     as _i4;
+import 'package:serverpod_auth_core_client/serverpod_auth_core_client.dart'
+    as _i5;
+export 'artist_profile/artist_profile.dart';
 export 'greetings/greeting.dart';
 export 'client.dart';
 
@@ -53,24 +55,31 @@ class Protocol extends _i1.SerializationManager {
       }
     }
 
-    if (t == _i2.Greeting) {
-      return _i2.Greeting.fromJson(data) as T;
+    if (t == _i2.ArtistProfile) {
+      return _i2.ArtistProfile.fromJson(data) as T;
     }
-    if (t == _i1.getType<_i2.Greeting?>()) {
-      return (data != null ? _i2.Greeting.fromJson(data) : null) as T;
+    if (t == _i3.Greeting) {
+      return _i3.Greeting.fromJson(data) as T;
     }
-    try {
-      return _i3.Protocol().deserialize<T>(data, t);
-    } on _i1.DeserializationTypeNotFoundException catch (_) {}
+    if (t == _i1.getType<_i2.ArtistProfile?>()) {
+      return (data != null ? _i2.ArtistProfile.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i3.Greeting?>()) {
+      return (data != null ? _i3.Greeting.fromJson(data) : null) as T;
+    }
     try {
       return _i4.Protocol().deserialize<T>(data, t);
+    } on _i1.DeserializationTypeNotFoundException catch (_) {}
+    try {
+      return _i5.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     return super.deserialize<T>(data, t);
   }
 
   static String? getClassNameForType(Type type) {
     return switch (type) {
-      _i2.Greeting => 'Greeting',
+      _i2.ArtistProfile => 'ArtistProfile',
+      _i3.Greeting => 'Greeting',
       _ => null,
     };
   }
@@ -85,14 +94,16 @@ class Protocol extends _i1.SerializationManager {
     }
 
     switch (data) {
-      case _i2.Greeting():
+      case _i2.ArtistProfile():
+        return 'ArtistProfile';
+      case _i3.Greeting():
         return 'Greeting';
     }
-    className = _i3.Protocol().getClassNameForObject(data);
+    className = _i4.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth_idp.$className';
     }
-    className = _i4.Protocol().getClassNameForObject(data);
+    className = _i5.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth_core.$className';
     }
@@ -105,16 +116,19 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName is! String) {
       return super.deserializeByClassName(data);
     }
+    if (dataClassName == 'ArtistProfile') {
+      return deserialize<_i2.ArtistProfile>(data['data']);
+    }
     if (dataClassName == 'Greeting') {
-      return deserialize<_i2.Greeting>(data['data']);
+      return deserialize<_i3.Greeting>(data['data']);
     }
     if (dataClassName.startsWith('serverpod_auth_idp.')) {
       data['className'] = dataClassName.substring(19);
-      return _i3.Protocol().deserializeByClassName(data);
+      return _i4.Protocol().deserializeByClassName(data);
     }
     if (dataClassName.startsWith('serverpod_auth_core.')) {
       data['className'] = dataClassName.substring(20);
-      return _i4.Protocol().deserializeByClassName(data);
+      return _i5.Protocol().deserializeByClassName(data);
     }
     return super.deserializeByClassName(data);
   }
@@ -129,10 +143,10 @@ class Protocol extends _i1.SerializationManager {
       return null;
     }
     try {
-      return _i3.Protocol().mapRecordToJson(record);
+      return _i4.Protocol().mapRecordToJson(record);
     } catch (_) {}
     try {
-      return _i4.Protocol().mapRecordToJson(record);
+      return _i5.Protocol().mapRecordToJson(record);
     } catch (_) {}
     throw Exception('Unsupported record type ${record.runtimeType}');
   }

--- a/apps/octattoo/octattoo_flutter/lib/main.dart
+++ b/apps/octattoo/octattoo_flutter/lib/main.dart
@@ -38,34 +38,42 @@ final _router = GoRouter(
       builder: (context, state, navigationShell) =>
           AppShell(navigationShell: navigationShell),
       branches: [
-        StatefulShellBranch(routes: [
-          GoRoute(
-            path: '/appointments',
-            builder: (context, state) =>
-                const PlaceholderScreen(title: 'Appointments'),
-          ),
-        ]),
-        StatefulShellBranch(routes: [
-          GoRoute(
-            path: '/customers',
-            builder: (context, state) =>
-                const PlaceholderScreen(title: 'Customers'),
-          ),
-        ]),
-        StatefulShellBranch(routes: [
-          GoRoute(
-            path: '/projects',
-            builder: (context, state) =>
-                const PlaceholderScreen(title: 'Projects'),
-          ),
-        ]),
-        StatefulShellBranch(routes: [
-          GoRoute(
-            path: '/profile',
-            builder: (context, state) =>
-                const PlaceholderScreen(title: 'Artist Profile'),
-          ),
-        ]),
+        StatefulShellBranch(
+          routes: [
+            GoRoute(
+              path: '/appointments',
+              builder: (context, state) =>
+                  const PlaceholderScreen(title: 'Appointments'),
+            ),
+          ],
+        ),
+        StatefulShellBranch(
+          routes: [
+            GoRoute(
+              path: '/customers',
+              builder: (context, state) =>
+                  const PlaceholderScreen(title: 'Customers'),
+            ),
+          ],
+        ),
+        StatefulShellBranch(
+          routes: [
+            GoRoute(
+              path: '/projects',
+              builder: (context, state) =>
+                  const PlaceholderScreen(title: 'Projects'),
+            ),
+          ],
+        ),
+        StatefulShellBranch(
+          routes: [
+            GoRoute(
+              path: '/profile',
+              builder: (context, state) =>
+                  const PlaceholderScreen(title: 'Artist Profile'),
+            ),
+          ],
+        ),
       ],
     ),
   ],
@@ -105,8 +113,10 @@ class AppShell extends StatelessWidget {
       body: navigationShell,
       bottomNavigationBar: NavigationBar(
         selectedIndex: navigationShell.currentIndex,
-        onDestinationSelected: (index) =>
-            navigationShell.goBranch(index, initialLocation: index == navigationShell.currentIndex),
+        onDestinationSelected: (index) => navigationShell.goBranch(
+          index,
+          initialLocation: index == navigationShell.currentIndex,
+        ),
         destinations: const [
           NavigationDestination(
             icon: Icon(Icons.calendar_today_outlined),
@@ -206,8 +216,8 @@ class _DrawerSectionHeader extends StatelessWidget {
       child: Text(
         title,
         style: Theme.of(context).textTheme.titleSmall?.copyWith(
-              color: Theme.of(context).colorScheme.primary,
-            ),
+          color: Theme.of(context).colorScheme.primary,
+        ),
       ),
     );
   }

--- a/apps/octattoo/octattoo_flutter/lib/main.dart
+++ b/apps/octattoo/octattoo_flutter/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:serverpod_auth_idp_flutter/serverpod_auth_idp_flutter.dart';
 import 'package:serverpod_flutter/serverpod_flutter.dart';
 
 import 'src/auth/sign_in_screen.dart';
+import 'src/customer/customer_list_screen.dart';
 
 late final Client client;
 
@@ -51,8 +52,7 @@ final _router = GoRouter(
           routes: [
             GoRoute(
               path: '/customers',
-              builder: (context, state) =>
-                  const PlaceholderScreen(title: 'Customers'),
+              builder: (context, state) => const CustomerListScreen(),
             ),
           ],
         ),

--- a/apps/octattoo/octattoo_flutter/lib/main.dart
+++ b/apps/octattoo/octattoo_flutter/lib/main.dart
@@ -4,6 +4,8 @@ import 'package:octattoo_client/octattoo_client.dart';
 import 'package:serverpod_auth_idp_flutter/serverpod_auth_idp_flutter.dart';
 import 'package:serverpod_flutter/serverpod_flutter.dart';
 
+import 'src/auth/sign_in_screen.dart';
+
 late final Client client;
 
 void main() async {
@@ -20,7 +22,18 @@ void main() async {
 
 final _router = GoRouter(
   initialLocation: '/appointments',
+  redirect: (context, state) {
+    final isAuthenticated = client.auth.isAuthenticated;
+    final isOnAuth = state.matchedLocation == '/sign-in';
+    if (!isAuthenticated && !isOnAuth) return '/sign-in';
+    if (isAuthenticated && isOnAuth) return '/appointments';
+    return null;
+  },
   routes: [
+    GoRoute(
+      path: '/sign-in',
+      builder: (context, state) => const SignInScreen(),
+    ),
     StatefulShellRoute.indexedStack(
       builder: (context, state, navigationShell) =>
           AppShell(navigationShell: navigationShell),

--- a/apps/octattoo/octattoo_flutter/lib/src/auth/sign_in_screen.dart
+++ b/apps/octattoo/octattoo_flutter/lib/src/auth/sign_in_screen.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+class SignInScreen extends StatelessWidget {
+  const SignInScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 400),
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  'octattoo',
+                  style: Theme.of(context).textTheme.headlineMedium,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 32),
+                const TextField(
+                  decoration: InputDecoration(labelText: 'Email'),
+                  keyboardType: TextInputType.emailAddress,
+                  autofillHints: [AutofillHints.email],
+                ),
+                const SizedBox(height: 16),
+                const TextField(
+                  decoration: InputDecoration(labelText: 'Password'),
+                  obscureText: true,
+                  autofillHints: [AutofillHints.password],
+                ),
+                const SizedBox(height: 24),
+                FilledButton(
+                  onPressed: () {},
+                  child: const Text('Sign in'),
+                ),
+                const SizedBox(height: 16),
+                TextButton(
+                  onPressed: () {},
+                  child: const Text('Create account'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/octattoo/octattoo_flutter/lib/src/customer/customer_detail_screen.dart
+++ b/apps/octattoo/octattoo_flutter/lib/src/customer/customer_detail_screen.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+class CustomerDetailScreen extends StatelessWidget {
+  const CustomerDetailScreen({super.key, required this.customerId});
+
+  final String customerId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Client Details')),
+      body: const Padding(
+        padding: EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Name', style: TextStyle(fontWeight: FontWeight.bold)),
+            SizedBox(height: 4),
+            Text('—'),
+            SizedBox(height: 16),
+            Text('Contact', style: TextStyle(fontWeight: FontWeight.bold)),
+            SizedBox(height: 4),
+            Text('—'),
+            SizedBox(height: 16),
+            Text('Notes', style: TextStyle(fontWeight: FontWeight.bold)),
+            SizedBox(height: 4),
+            Text('—'),
+            SizedBox(height: 24),
+            Text(
+              'Relationship History',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            SizedBox(height: 4),
+            Text('No history yet'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/octattoo/octattoo_flutter/lib/src/customer/customer_form_screen.dart
+++ b/apps/octattoo/octattoo_flutter/lib/src/customer/customer_form_screen.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+
+import 'customer_form_validator.dart';
+
+class CustomerFormScreen extends StatefulWidget {
+  const CustomerFormScreen({super.key});
+
+  @override
+  State<CustomerFormScreen> createState() => _CustomerFormScreenState();
+}
+
+class _CustomerFormScreenState extends State<CustomerFormScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _emailController = TextEditingController();
+  final _phoneController = TextEditingController();
+  final _notesController = TextEditingController();
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _emailController.dispose();
+    _phoneController.dispose();
+    _notesController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('New Client')),
+      body: Form(
+        key: _formKey,
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            TextFormField(
+              controller: _nameController,
+              decoration: const InputDecoration(labelText: 'Name'),
+              validator: CustomerFormValidator.validateName,
+            ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: 'Email'),
+              keyboardType: TextInputType.emailAddress,
+              validator: CustomerFormValidator.validateEmail,
+            ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _phoneController,
+              decoration: const InputDecoration(labelText: 'Phone'),
+              keyboardType: TextInputType.phone,
+            ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _notesController,
+              decoration: const InputDecoration(labelText: 'Notes'),
+              maxLines: 3,
+            ),
+            const SizedBox(height: 24),
+            FilledButton(
+              onPressed: _submit,
+              child: const Text('Save'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _submit() {
+    // Cross-field validation
+    final contactError = CustomerFormValidator.validateContact(
+      email: _emailController.text.isEmpty ? null : _emailController.text,
+      phone: _phoneController.text.isEmpty ? null : _phoneController.text,
+    );
+    if (contactError != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(contactError)),
+      );
+      return;
+    }
+
+    if (_formKey.currentState!.validate()) {
+      // TODO: call endpoint
+      Navigator.of(context).pop();
+    }
+  }
+}

--- a/apps/octattoo/octattoo_flutter/lib/src/customer/customer_form_validator.dart
+++ b/apps/octattoo/octattoo_flutter/lib/src/customer/customer_form_validator.dart
@@ -1,0 +1,23 @@
+class CustomerFormValidator {
+  static String? validateName(String? value) {
+    if (value == null || value.isEmpty) return 'Name is required';
+    return null;
+  }
+
+  static String? validateContact({String? email, String? phone}) {
+    final hasEmail = email != null && email.isNotEmpty;
+    final hasPhone = phone != null && phone.isNotEmpty;
+    if (!hasEmail && !hasPhone) {
+      return 'At least one of email or phone is required';
+    }
+    return null;
+  }
+
+  static String? validateEmail(String? value) {
+    if (value == null || value.isEmpty) return null;
+    if (!value.contains('@') || !value.contains('.')) {
+      return 'Invalid email format';
+    }
+    return null;
+  }
+}

--- a/apps/octattoo/octattoo_flutter/lib/src/customer/customer_list_screen.dart
+++ b/apps/octattoo/octattoo_flutter/lib/src/customer/customer_list_screen.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+
+import 'customer_list_viewmodel.dart';
+
+class CustomerListScreen extends StatefulWidget {
+  const CustomerListScreen({super.key});
+
+  @override
+  State<CustomerListScreen> createState() => _CustomerListScreenState();
+}
+
+class _CustomerListScreenState extends State<CustomerListScreen> {
+  final _viewModel = CustomerListViewModel();
+
+  @override
+  void dispose() {
+    _viewModel.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: _viewModel,
+      builder: (context, _) {
+        return Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(8),
+              child: SearchBar(
+                hintText: 'Search clients...',
+                onChanged: _viewModel.updateSearch,
+                leading: const Icon(Icons.search),
+              ),
+            ),
+            Expanded(
+              child: _viewModel.isLoading
+                  ? const Center(child: CircularProgressIndicator())
+                  : _viewModel.filteredCustomers.isEmpty
+                  ? const Center(child: Text('No clients found'))
+                  : ListView.builder(
+                      itemCount: _viewModel.filteredCustomers.length,
+                      itemBuilder: (context, index) {
+                        final customer = _viewModel.filteredCustomers[index];
+                        return ListTile(
+                          title: Text(customer.name),
+                          subtitle: Text(customer.subtitle),
+                          onTap: () {
+                            // TODO: navigate to detail
+                          },
+                        );
+                      },
+                    ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/apps/octattoo/octattoo_flutter/lib/src/customer/customer_list_viewmodel.dart
+++ b/apps/octattoo/octattoo_flutter/lib/src/customer/customer_list_viewmodel.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/foundation.dart';
+
+class CustomerListItem {
+  final String id;
+  final String name;
+  final String subtitle;
+
+  CustomerListItem({
+    required this.id,
+    required this.name,
+    required this.subtitle,
+  });
+}
+
+class CustomerListViewModel extends ChangeNotifier {
+  List<CustomerListItem> _customers = [];
+  String _searchQuery = '';
+  final bool _isLoading = false;
+
+  List<CustomerListItem> get customers => _customers;
+  String get searchQuery => _searchQuery;
+  bool get isLoading => _isLoading;
+
+  List<CustomerListItem> get filteredCustomers {
+    if (_searchQuery.isEmpty) return _customers;
+    final query = _searchQuery.toLowerCase();
+    return _customers.where((c) {
+      return c.name.toLowerCase().contains(query) ||
+          c.subtitle.toLowerCase().contains(query);
+    }).toList();
+  }
+
+  void updateSearch(String query) {
+    _searchQuery = query;
+    notifyListeners();
+  }
+
+  /// For testing only.
+  void setCustomersForTest(List<CustomerListItem> customers) {
+    _customers = customers;
+    notifyListeners();
+  }
+}

--- a/apps/octattoo/octattoo_flutter/test/customer_form_validator_test.dart
+++ b/apps/octattoo/octattoo_flutter/test/customer_form_validator_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:octattoo_flutter/src/customer/customer_form_validator.dart';
+
+void main() {
+  group('CustomerFormValidator', () {
+    test('name is required', () {
+      expect(CustomerFormValidator.validateName(null), isNotNull);
+      expect(CustomerFormValidator.validateName(''), isNotNull);
+      expect(CustomerFormValidator.validateName('Alice'), isNull);
+    });
+
+    test('at least one of email or phone required', () {
+      expect(
+        CustomerFormValidator.validateContact(email: null, phone: null),
+        isNotNull,
+      );
+      expect(
+        CustomerFormValidator.validateContact(email: '', phone: ''),
+        isNotNull,
+      );
+      expect(
+        CustomerFormValidator.validateContact(
+          email: 'a@b.com',
+          phone: null,
+        ),
+        isNull,
+      );
+      expect(
+        CustomerFormValidator.validateContact(
+          email: null,
+          phone: '+33612345678',
+        ),
+        isNull,
+      );
+    });
+
+    test('email format validation', () {
+      expect(CustomerFormValidator.validateEmail('not-an-email'), isNotNull);
+      expect(CustomerFormValidator.validateEmail('valid@example.com'), isNull);
+      expect(CustomerFormValidator.validateEmail(null), isNull);
+      expect(CustomerFormValidator.validateEmail(''), isNull);
+    });
+  });
+}

--- a/apps/octattoo/octattoo_flutter/test/customer_list_viewmodel_test.dart
+++ b/apps/octattoo/octattoo_flutter/test/customer_list_viewmodel_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:octattoo_flutter/src/customer/customer_list_viewmodel.dart';
+
+void main() {
+  group('CustomerListViewModel', () {
+    test('initial state is empty and not loading', () {
+      final vm = CustomerListViewModel();
+      expect(vm.customers, isEmpty);
+      expect(vm.isLoading, isFalse);
+      expect(vm.searchQuery, isEmpty);
+    });
+
+    test('updateSearch updates the search query', () {
+      final vm = CustomerListViewModel();
+      vm.updateSearch('Alice');
+      expect(vm.searchQuery, 'Alice');
+    });
+
+    test('filteredCustomers filters by name', () {
+      final vm = CustomerListViewModel();
+      vm.setCustomersForTest([
+        CustomerListItem(id: '1', name: 'Alice', subtitle: 'alice@test.com'),
+        CustomerListItem(id: '2', name: 'Bob', subtitle: '+33600000000'),
+      ]);
+      vm.updateSearch('Ali');
+      expect(vm.filteredCustomers, hasLength(1));
+      expect(vm.filteredCustomers.first.name, 'Alice');
+    });
+
+    test('filteredCustomers filters by subtitle (email/phone)', () {
+      final vm = CustomerListViewModel();
+      vm.setCustomersForTest([
+        CustomerListItem(id: '1', name: 'Alice', subtitle: 'alice@test.com'),
+        CustomerListItem(id: '2', name: 'Bob', subtitle: '+33600000000'),
+      ]);
+      vm.updateSearch('alice@');
+      expect(vm.filteredCustomers, hasLength(1));
+      expect(vm.filteredCustomers.first.name, 'Alice');
+    });
+
+    test('empty search returns all customers', () {
+      final vm = CustomerListViewModel();
+      vm.setCustomersForTest([
+        CustomerListItem(id: '1', name: 'Alice', subtitle: 'alice@test.com'),
+        CustomerListItem(id: '2', name: 'Bob', subtitle: '+33600000000'),
+      ]);
+      vm.updateSearch('');
+      expect(vm.filteredCustomers, hasLength(2));
+    });
+  });
+}

--- a/apps/octattoo/octattoo_flutter/test/sign_in_screen_test.dart
+++ b/apps/octattoo/octattoo_flutter/test/sign_in_screen_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:octattoo_flutter/src/auth/sign_in_screen.dart';
+
+void main() {
+  testWidgets('SignInScreen shows email and password fields', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: SignInScreen()),
+    );
+
+    expect(find.byType(TextField), findsAtLeast(2));
+    expect(find.text('Sign in'), findsOneWidget);
+  });
+
+  testWidgets('SignInScreen shows sign-up link', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: SignInScreen()),
+    );
+
+    expect(find.text('Create account'), findsOneWidget);
+  });
+}

--- a/apps/octattoo/octattoo_flutter/test/widget_test.dart
+++ b/apps/octattoo/octattoo_flutter/test/widget_test.dart
@@ -12,34 +12,41 @@ void main() {
           builder: (context, state, navigationShell) =>
               AppShell(navigationShell: navigationShell),
           branches: [
-            StatefulShellBranch(routes: [
-              GoRoute(
-                path: '/appointments',
-                builder: (_, _) =>
-                    const PlaceholderScreen(title: 'Appointments'),
-              ),
-            ]),
-            StatefulShellBranch(routes: [
-              GoRoute(
-                path: '/customers',
-                builder: (_, _) =>
-                    const PlaceholderScreen(title: 'Customers'),
-              ),
-            ]),
-            StatefulShellBranch(routes: [
-              GoRoute(
-                path: '/projects',
-                builder: (_, _) =>
-                    const PlaceholderScreen(title: 'Projects'),
-              ),
-            ]),
-            StatefulShellBranch(routes: [
-              GoRoute(
-                path: '/profile',
-                builder: (_, _) =>
-                    const PlaceholderScreen(title: 'Artist Profile'),
-              ),
-            ]),
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/appointments',
+                  builder: (_, _) =>
+                      const PlaceholderScreen(title: 'Appointments'),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/customers',
+                  builder: (_, _) =>
+                      const PlaceholderScreen(title: 'Customers'),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/projects',
+                  builder: (_, _) => const PlaceholderScreen(title: 'Projects'),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/profile',
+                  builder: (_, _) =>
+                      const PlaceholderScreen(title: 'Artist Profile'),
+                ),
+              ],
+            ),
           ],
         ),
       ],
@@ -62,20 +69,24 @@ void main() {
           builder: (context, state, navigationShell) =>
               AppShell(navigationShell: navigationShell),
           branches: [
-            StatefulShellBranch(routes: [
-              GoRoute(
-                path: '/appointments',
-                builder: (_, _) =>
-                    const PlaceholderScreen(title: 'Appointments'),
-              ),
-            ]),
-            StatefulShellBranch(routes: [
-              GoRoute(
-                path: '/customers',
-                builder: (_, _) =>
-                    const PlaceholderScreen(title: 'Customers'),
-              ),
-            ]),
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/appointments',
+                  builder: (_, _) =>
+                      const PlaceholderScreen(title: 'Appointments'),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/customers',
+                  builder: (_, _) =>
+                      const PlaceholderScreen(title: 'Customers'),
+                ),
+              ],
+            ),
           ],
         ),
       ],
@@ -99,13 +110,15 @@ void main() {
           builder: (context, state, navigationShell) =>
               AppShell(navigationShell: navigationShell),
           branches: [
-            StatefulShellBranch(routes: [
-              GoRoute(
-                path: '/appointments',
-                builder: (_, _) =>
-                    const PlaceholderScreen(title: 'Appointments'),
-              ),
-            ]),
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/appointments',
+                  builder: (_, _) =>
+                      const PlaceholderScreen(title: 'Appointments'),
+                ),
+              ],
+            ),
           ],
         ),
       ],
@@ -114,8 +127,9 @@ void main() {
     await tester.pumpWidget(MaterialApp.router(routerConfig: router));
     await tester.pumpAndSettle();
 
-    final scaffoldState =
-        tester.firstState<ScaffoldState>(find.byType(Scaffold));
+    final scaffoldState = tester.firstState<ScaffoldState>(
+      find.byType(Scaffold),
+    );
     scaffoldState.openDrawer();
     await tester.pumpAndSettle();
 

--- a/apps/octattoo/octattoo_flutter/test/widget_test.dart
+++ b/apps/octattoo/octattoo_flutter/test/widget_test.dart
@@ -1,10 +1,51 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:octattoo_flutter/main.dart';
 
 void main() {
   testWidgets('AppShell shows 4 bottom nav destinations', (tester) async {
-    await tester.pumpWidget(const OctattooApp());
+    final router = GoRouter(
+      initialLocation: '/appointments',
+      routes: [
+        StatefulShellRoute.indexedStack(
+          builder: (context, state, navigationShell) =>
+              AppShell(navigationShell: navigationShell),
+          branches: [
+            StatefulShellBranch(routes: [
+              GoRoute(
+                path: '/appointments',
+                builder: (_, _) =>
+                    const PlaceholderScreen(title: 'Appointments'),
+              ),
+            ]),
+            StatefulShellBranch(routes: [
+              GoRoute(
+                path: '/customers',
+                builder: (_, _) =>
+                    const PlaceholderScreen(title: 'Customers'),
+              ),
+            ]),
+            StatefulShellBranch(routes: [
+              GoRoute(
+                path: '/projects',
+                builder: (_, _) =>
+                    const PlaceholderScreen(title: 'Projects'),
+              ),
+            ]),
+            StatefulShellBranch(routes: [
+              GoRoute(
+                path: '/profile',
+                builder: (_, _) =>
+                    const PlaceholderScreen(title: 'Artist Profile'),
+              ),
+            ]),
+          ],
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
     await tester.pumpAndSettle();
 
     expect(find.text('Appointments'), findsWidgets);
@@ -14,24 +55,65 @@ void main() {
   });
 
   testWidgets('Bottom nav switches tabs', (tester) async {
-    await tester.pumpWidget(const OctattooApp());
+    final router = GoRouter(
+      initialLocation: '/appointments',
+      routes: [
+        StatefulShellRoute.indexedStack(
+          builder: (context, state, navigationShell) =>
+              AppShell(navigationShell: navigationShell),
+          branches: [
+            StatefulShellBranch(routes: [
+              GoRoute(
+                path: '/appointments',
+                builder: (_, _) =>
+                    const PlaceholderScreen(title: 'Appointments'),
+              ),
+            ]),
+            StatefulShellBranch(routes: [
+              GoRoute(
+                path: '/customers',
+                builder: (_, _) =>
+                    const PlaceholderScreen(title: 'Customers'),
+              ),
+            ]),
+          ],
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
     await tester.pumpAndSettle();
 
-    // Initially on Appointments
     expect(find.text('Appointments'), findsWidgets);
 
-    // Tap Customers tab
     await tester.tap(find.text('Customers'));
     await tester.pumpAndSettle();
-    // The Customers placeholder screen should be visible
     expect(find.text('Customers'), findsWidgets);
   });
 
   testWidgets('Drawer opens and shows grouped sections', (tester) async {
-    await tester.pumpWidget(const OctattooApp());
+    final router = GoRouter(
+      initialLocation: '/appointments',
+      routes: [
+        StatefulShellRoute.indexedStack(
+          builder: (context, state, navigationShell) =>
+              AppShell(navigationShell: navigationShell),
+          branches: [
+            StatefulShellBranch(routes: [
+              GoRoute(
+                path: '/appointments',
+                builder: (_, _) =>
+                    const PlaceholderScreen(title: 'Appointments'),
+              ),
+            ]),
+          ],
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
     await tester.pumpAndSettle();
 
-    // Open drawer via scaffold
     final scaffoldState =
         tester.firstState<ScaffoldState>(find.byType(Scaffold));
     scaffoldState.openDrawer();

--- a/apps/octattoo/octattoo_server/lib/src/artist_profile/artist_profile.spy.yaml
+++ b/apps/octattoo/octattoo_server/lib/src/artist_profile/artist_profile.spy.yaml
@@ -1,0 +1,15 @@
+### An artist's brand identity, auto-created on account registration.
+class: ArtistProfile
+table: artist_profile
+
+fields:
+  id: UuidValue?, defaultPersist=random_v7
+  ### The auth user this profile belongs to.
+  authUserId: UuidValue
+  ### Display name for the artist.
+  name: String
+
+indexes:
+  artist_profile_auth_user_id_unique:
+    fields: authUserId
+    unique: true

--- a/apps/octattoo/octattoo_server/lib/src/artist_profile/artist_profile_endpoint.dart
+++ b/apps/octattoo/octattoo_server/lib/src/artist_profile/artist_profile_endpoint.dart
@@ -1,0 +1,29 @@
+import 'package:serverpod/serverpod.dart';
+
+import '../generated/protocol.dart';
+
+class ArtistProfileEndpoint extends Endpoint {
+  @override
+  bool get requireLogin => true;
+
+  /// Returns the current user's artist profile ID.
+  /// Auto-creates the profile on first call.
+  Future<UuidValue> getMyProfileId(Session session) async {
+    final authUserId = session.authenticated!.userIdentifier;
+
+    var profile = await ArtistProfile.db.findFirstRow(
+      session,
+      where: (t) => t.authUserId.equals(UuidValue.fromString(authUserId)),
+    );
+
+    profile ??= await ArtistProfile.db.insertRow(
+      session,
+      ArtistProfile(
+        authUserId: UuidValue.fromString(authUserId),
+        name: 'Artist',
+      ),
+    );
+
+    return profile.id!;
+  }
+}

--- a/apps/octattoo/octattoo_server/lib/src/customer/create_customer_result.spy.yaml
+++ b/apps/octattoo/octattoo_server/lib/src/customer/create_customer_result.spy.yaml
@@ -1,0 +1,9 @@
+### Result of creating a customer, includes potential duplicates.
+class: CreateCustomerResult
+serverOnly: false
+
+fields:
+  ### The newly created customer.
+  customer: Customer
+  ### Potential duplicate customers (non-blocking).
+  potentialDuplicates: List<Customer>

--- a/apps/octattoo/octattoo_server/lib/src/customer/customer.spy.yaml
+++ b/apps/octattoo/octattoo_server/lib/src/customer/customer.spy.yaml
@@ -1,0 +1,26 @@
+### A person who receives tattoos. Scoped to a single Artist Profile.
+class: Customer
+table: customer
+
+fields:
+  id: UuidValue?, defaultPersist=random_v7
+  ### The artist profile this customer belongs to.
+  artistProfileId: UuidValue
+  ### Display name.
+  name: String
+  ### Contact email (at least one of email/phone required).
+  email: String?
+  ### Contact phone (at least one of email/phone required).
+  phone: String?
+  ### Free-form notes.
+  notes: String?
+  ### When this customer was created.
+  createdAt: DateTime?, defaultPersist=now
+
+indexes:
+  customer_artist_profile_id_idx:
+    fields: artistProfileId
+  customer_email_idx:
+    fields: artistProfileId, email
+  customer_phone_idx:
+    fields: artistProfileId, phone

--- a/apps/octattoo/octattoo_server/lib/src/customer/customer_endpoint.dart
+++ b/apps/octattoo/octattoo_server/lib/src/customer/customer_endpoint.dart
@@ -1,0 +1,172 @@
+import 'package:serverpod/serverpod.dart';
+
+import '../generated/protocol.dart';
+
+class CustomerEndpoint extends Endpoint {
+  @override
+  bool get requireLogin => true;
+
+  /// Validates that at least one of email/phone is provided.
+  void validateContact({required String? email, required String? phone}) {
+    if (email == null && phone == null) {
+      throw ArgumentError('At least one of email or phone is required');
+    }
+  }
+
+  /// Finds duplicates in a list by matching email or phone.
+  List<Customer> findDuplicatesIn({
+    required String? email,
+    required String? phone,
+    required List<Customer> existing,
+  }) {
+    return existing.where((c) {
+      if (email != null && c.email == email) return true;
+      if (phone != null && c.phone == phone) return true;
+      return false;
+    }).toList();
+  }
+
+  /// Creates a customer, returning potential duplicates.
+  Future<CreateCustomerResult> createCustomer(
+    Session session, {
+    required String name,
+    String? email,
+    String? phone,
+    String? notes,
+  }) async {
+    validateContact(email: email, phone: phone);
+
+    final artistProfileId = await _getArtistProfileId(session);
+
+    // Check for duplicates
+    final existing = await Customer.db.find(
+      session,
+      where: (t) {
+        final conditions = <Expression>[];
+        conditions.add(t.artistProfileId.equals(artistProfileId));
+        if (email != null) conditions.add(t.email.equals(email));
+        if (phone != null) conditions.add(t.phone.equals(phone));
+        // Match any contact field within same profile
+        if (email != null || phone != null) {
+          final contactMatch = <Expression>[];
+          if (email != null) contactMatch.add(t.email.equals(email));
+          if (phone != null) contactMatch.add(t.phone.equals(phone));
+          return t.artistProfileId.equals(artistProfileId) &
+              contactMatch.reduce((a, b) => a | b);
+        }
+        return t.artistProfileId.equals(artistProfileId);
+      },
+    );
+
+    final customer = await Customer.db.insertRow(
+      session,
+      Customer(
+        artistProfileId: artistProfileId,
+        name: name,
+        email: email,
+        phone: phone,
+        notes: notes,
+      ),
+    );
+
+    return CreateCustomerResult(
+      customer: customer,
+      potentialDuplicates: existing,
+    );
+  }
+
+  /// Lists customers for the current artist profile.
+  Future<List<Customer>> listCustomers(
+    Session session, {
+    String? search,
+  }) async {
+    final artistProfileId = await _getArtistProfileId(session);
+
+    return Customer.db.find(
+      session,
+      where: (t) {
+        var condition = t.artistProfileId.equals(artistProfileId);
+        if (search != null && search.isNotEmpty) {
+          condition =
+              condition &
+              (t.name.ilike('%$search%') |
+                  t.email.ilike('%$search%') |
+                  t.phone.ilike('%$search%'));
+        }
+        return condition;
+      },
+      orderBy: (t) => t.name,
+    );
+  }
+
+  /// Gets a single customer by ID (scoped to artist profile).
+  Future<Customer?> getCustomer(Session session, UuidValue customerId) async {
+    final artistProfileId = await _getArtistProfileId(session);
+
+    return Customer.db.findFirstRow(
+      session,
+      where: (t) =>
+          t.id.equals(customerId) & t.artistProfileId.equals(artistProfileId),
+    );
+  }
+
+  /// Updates a customer (scoped to artist profile).
+  Future<Customer?> updateCustomer(
+    Session session, {
+    required UuidValue customerId,
+    required String name,
+    String? email,
+    String? phone,
+    String? notes,
+  }) async {
+    validateContact(email: email, phone: phone);
+
+    final artistProfileId = await _getArtistProfileId(session);
+
+    final existing = await Customer.db.findFirstRow(
+      session,
+      where: (t) =>
+          t.id.equals(customerId) & t.artistProfileId.equals(artistProfileId),
+    );
+
+    if (existing == null) return null;
+
+    existing.name = name;
+    existing.email = email;
+    existing.phone = phone;
+    existing.notes = notes;
+
+    return Customer.db.updateRow(session, existing);
+  }
+
+  /// Deletes a customer (scoped to artist profile).
+  Future<bool> deleteCustomer(Session session, UuidValue customerId) async {
+    final artistProfileId = await _getArtistProfileId(session);
+
+    final existing = await Customer.db.findFirstRow(
+      session,
+      where: (t) =>
+          t.id.equals(customerId) & t.artistProfileId.equals(artistProfileId),
+    );
+
+    if (existing == null) return false;
+
+    await Customer.db.deleteRow(session, existing);
+    return true;
+  }
+
+  Future<UuidValue> _getArtistProfileId(Session session) async {
+    final authUserId = session.authenticated!.userIdentifier;
+
+    final profile = await ArtistProfile.db.findFirstRow(
+      session,
+      where: (t) => t.authUserId.equals(UuidValue.fromString(authUserId)),
+    );
+
+    if (profile == null) {
+      throw StateError('No artist profile found for user');
+    }
+
+    return profile.id!;
+  }
+}

--- a/apps/octattoo/octattoo_server/lib/src/generated/artist_profile/artist_profile.dart
+++ b/apps/octattoo/octattoo_server/lib/src/generated/artist_profile/artist_profile.dart
@@ -1,0 +1,507 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+
+/// An artist's brand identity, auto-created on account registration.
+abstract class ArtistProfile
+    implements _i1.TableRow<_i1.UuidValue?>, _i1.ProtocolSerialization {
+  ArtistProfile._({
+    this.id,
+    required this.authUserId,
+    required this.name,
+  });
+
+  factory ArtistProfile({
+    _i1.UuidValue? id,
+    required _i1.UuidValue authUserId,
+    required String name,
+  }) = _ArtistProfileImpl;
+
+  factory ArtistProfile.fromJson(Map<String, dynamic> jsonSerialization) {
+    return ArtistProfile(
+      id: jsonSerialization['id'] == null
+          ? null
+          : _i1.UuidValueJsonExtension.fromJson(jsonSerialization['id']),
+      authUserId: _i1.UuidValueJsonExtension.fromJson(
+        jsonSerialization['authUserId'],
+      ),
+      name: jsonSerialization['name'] as String,
+    );
+  }
+
+  static final t = ArtistProfileTable();
+
+  static const db = ArtistProfileRepository._();
+
+  @override
+  _i1.UuidValue? id;
+
+  /// The auth user this profile belongs to.
+  _i1.UuidValue authUserId;
+
+  /// Display name for the artist.
+  String name;
+
+  @override
+  _i1.Table<_i1.UuidValue?> get table => t;
+
+  /// Returns a shallow copy of this [ArtistProfile]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  ArtistProfile copyWith({
+    _i1.UuidValue? id,
+    _i1.UuidValue? authUserId,
+    String? name,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      '__className__': 'ArtistProfile',
+      if (id != null) 'id': id?.toJson(),
+      'authUserId': authUserId.toJson(),
+      'name': name,
+    };
+  }
+
+  @override
+  Map<String, dynamic> toJsonForProtocol() {
+    return {
+      '__className__': 'ArtistProfile',
+      if (id != null) 'id': id?.toJson(),
+      'authUserId': authUserId.toJson(),
+      'name': name,
+    };
+  }
+
+  static ArtistProfileInclude include() {
+    return ArtistProfileInclude._();
+  }
+
+  static ArtistProfileIncludeList includeList({
+    _i1.WhereExpressionBuilder<ArtistProfileTable>? where,
+    int? limit,
+    int? offset,
+    _i1.OrderByBuilder<ArtistProfileTable>? orderBy,
+    bool orderDescending = false,
+    _i1.OrderByListBuilder<ArtistProfileTable>? orderByList,
+    ArtistProfileInclude? include,
+  }) {
+    return ArtistProfileIncludeList._(
+      where: where,
+      limit: limit,
+      offset: offset,
+      orderBy: orderBy?.call(ArtistProfile.t),
+      orderDescending: orderDescending,
+      orderByList: orderByList?.call(ArtistProfile.t),
+      include: include,
+    );
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _Undefined {}
+
+class _ArtistProfileImpl extends ArtistProfile {
+  _ArtistProfileImpl({
+    _i1.UuidValue? id,
+    required _i1.UuidValue authUserId,
+    required String name,
+  }) : super._(
+         id: id,
+         authUserId: authUserId,
+         name: name,
+       );
+
+  /// Returns a shallow copy of this [ArtistProfile]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  ArtistProfile copyWith({
+    Object? id = _Undefined,
+    _i1.UuidValue? authUserId,
+    String? name,
+  }) {
+    return ArtistProfile(
+      id: id is _i1.UuidValue? ? id : this.id,
+      authUserId: authUserId ?? this.authUserId,
+      name: name ?? this.name,
+    );
+  }
+}
+
+class ArtistProfileUpdateTable extends _i1.UpdateTable<ArtistProfileTable> {
+  ArtistProfileUpdateTable(super.table);
+
+  _i1.ColumnValue<_i1.UuidValue, _i1.UuidValue> authUserId(
+    _i1.UuidValue value,
+  ) => _i1.ColumnValue(
+    table.authUserId,
+    value,
+  );
+
+  _i1.ColumnValue<String, String> name(String value) => _i1.ColumnValue(
+    table.name,
+    value,
+  );
+}
+
+class ArtistProfileTable extends _i1.Table<_i1.UuidValue?> {
+  ArtistProfileTable({super.tableRelation})
+    : super(tableName: 'artist_profile') {
+    updateTable = ArtistProfileUpdateTable(this);
+    authUserId = _i1.ColumnUuid(
+      'authUserId',
+      this,
+    );
+    name = _i1.ColumnString(
+      'name',
+      this,
+    );
+  }
+
+  late final ArtistProfileUpdateTable updateTable;
+
+  /// The auth user this profile belongs to.
+  late final _i1.ColumnUuid authUserId;
+
+  /// Display name for the artist.
+  late final _i1.ColumnString name;
+
+  @override
+  List<_i1.Column> get columns => [
+    id,
+    authUserId,
+    name,
+  ];
+}
+
+class ArtistProfileInclude extends _i1.IncludeObject {
+  ArtistProfileInclude._();
+
+  @override
+  Map<String, _i1.Include?> get includes => {};
+
+  @override
+  _i1.Table<_i1.UuidValue?> get table => ArtistProfile.t;
+}
+
+class ArtistProfileIncludeList extends _i1.IncludeList {
+  ArtistProfileIncludeList._({
+    _i1.WhereExpressionBuilder<ArtistProfileTable>? where,
+    super.limit,
+    super.offset,
+    super.orderBy,
+    super.orderDescending,
+    super.orderByList,
+    super.include,
+  }) {
+    super.where = where?.call(ArtistProfile.t);
+  }
+
+  @override
+  Map<String, _i1.Include?> get includes => include?.includes ?? {};
+
+  @override
+  _i1.Table<_i1.UuidValue?> get table => ArtistProfile.t;
+}
+
+class ArtistProfileRepository {
+  const ArtistProfileRepository._();
+
+  /// Returns a list of [ArtistProfile]s matching the given query parameters.
+  ///
+  /// Use [where] to specify which items to include in the return value.
+  /// If none is specified, all items will be returned.
+  ///
+  /// To specify the order of the items use [orderBy] or [orderByList]
+  /// when sorting by multiple columns.
+  ///
+  /// The maximum number of items can be set by [limit]. If no limit is set,
+  /// all items matching the query will be returned.
+  ///
+  /// [offset] defines how many items to skip, after which [limit] (or all)
+  /// items are read from the database.
+  ///
+  /// ```dart
+  /// var persons = await Persons.db.find(
+  ///   session,
+  ///   where: (t) => t.lastName.equals('Jones'),
+  ///   orderBy: (t) => t.firstName,
+  ///   limit: 100,
+  /// );
+  /// ```
+  Future<List<ArtistProfile>> find(
+    _i1.DatabaseSession session, {
+    _i1.WhereExpressionBuilder<ArtistProfileTable>? where,
+    int? limit,
+    int? offset,
+    _i1.OrderByBuilder<ArtistProfileTable>? orderBy,
+    bool orderDescending = false,
+    _i1.OrderByListBuilder<ArtistProfileTable>? orderByList,
+    _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
+  }) async {
+    return session.db.find<ArtistProfile>(
+      where: where?.call(ArtistProfile.t),
+      orderBy: orderBy?.call(ArtistProfile.t),
+      orderByList: orderByList?.call(ArtistProfile.t),
+      orderDescending: orderDescending,
+      limit: limit,
+      offset: offset,
+      transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
+    );
+  }
+
+  /// Returns the first matching [ArtistProfile] matching the given query parameters.
+  ///
+  /// Use [where] to specify which items to include in the return value.
+  /// If none is specified, all items will be returned.
+  ///
+  /// To specify the order use [orderBy] or [orderByList]
+  /// when sorting by multiple columns.
+  ///
+  /// [offset] defines how many items to skip, after which the next one will be picked.
+  ///
+  /// ```dart
+  /// var youngestPerson = await Persons.db.findFirstRow(
+  ///   session,
+  ///   where: (t) => t.lastName.equals('Jones'),
+  ///   orderBy: (t) => t.age,
+  /// );
+  /// ```
+  Future<ArtistProfile?> findFirstRow(
+    _i1.DatabaseSession session, {
+    _i1.WhereExpressionBuilder<ArtistProfileTable>? where,
+    int? offset,
+    _i1.OrderByBuilder<ArtistProfileTable>? orderBy,
+    bool orderDescending = false,
+    _i1.OrderByListBuilder<ArtistProfileTable>? orderByList,
+    _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
+  }) async {
+    return session.db.findFirstRow<ArtistProfile>(
+      where: where?.call(ArtistProfile.t),
+      orderBy: orderBy?.call(ArtistProfile.t),
+      orderByList: orderByList?.call(ArtistProfile.t),
+      orderDescending: orderDescending,
+      offset: offset,
+      transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
+    );
+  }
+
+  /// Finds a single [ArtistProfile] by its [id] or null if no such row exists.
+  Future<ArtistProfile?> findById(
+    _i1.DatabaseSession session,
+    _i1.UuidValue id, {
+    _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
+  }) async {
+    return session.db.findById<ArtistProfile>(
+      id,
+      transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
+    );
+  }
+
+  /// Inserts all [ArtistProfile]s in the list and returns the inserted rows.
+  ///
+  /// The returned [ArtistProfile]s will have their `id` fields set.
+  ///
+  /// This is an atomic operation, meaning that if one of the rows fails to
+  /// insert, none of the rows will be inserted.
+  ///
+  /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
+  /// rows are silently skipped, and only the successfully inserted rows are
+  /// returned.
+  Future<List<ArtistProfile>> insert(
+    _i1.DatabaseSession session,
+    List<ArtistProfile> rows, {
+    _i1.Transaction? transaction,
+    bool ignoreConflicts = false,
+  }) async {
+    return session.db.insert<ArtistProfile>(
+      rows,
+      transaction: transaction,
+      ignoreConflicts: ignoreConflicts,
+    );
+  }
+
+  /// Inserts a single [ArtistProfile] and returns the inserted row.
+  ///
+  /// The returned [ArtistProfile] will have its `id` field set.
+  Future<ArtistProfile> insertRow(
+    _i1.DatabaseSession session,
+    ArtistProfile row, {
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.insertRow<ArtistProfile>(
+      row,
+      transaction: transaction,
+    );
+  }
+
+  /// Updates all [ArtistProfile]s in the list and returns the updated rows. If
+  /// [columns] is provided, only those columns will be updated. Defaults to
+  /// all columns.
+  /// This is an atomic operation, meaning that if one of the rows fails to
+  /// update, none of the rows will be updated.
+  Future<List<ArtistProfile>> update(
+    _i1.DatabaseSession session,
+    List<ArtistProfile> rows, {
+    _i1.ColumnSelections<ArtistProfileTable>? columns,
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.update<ArtistProfile>(
+      rows,
+      columns: columns?.call(ArtistProfile.t),
+      transaction: transaction,
+    );
+  }
+
+  /// Updates a single [ArtistProfile]. The row needs to have its id set.
+  /// Optionally, a list of [columns] can be provided to only update those
+  /// columns. Defaults to all columns.
+  Future<ArtistProfile> updateRow(
+    _i1.DatabaseSession session,
+    ArtistProfile row, {
+    _i1.ColumnSelections<ArtistProfileTable>? columns,
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.updateRow<ArtistProfile>(
+      row,
+      columns: columns?.call(ArtistProfile.t),
+      transaction: transaction,
+    );
+  }
+
+  /// Updates a single [ArtistProfile] by its [id] with the specified [columnValues].
+  /// Returns the updated row or null if no row with the given id exists.
+  Future<ArtistProfile?> updateById(
+    _i1.DatabaseSession session,
+    _i1.UuidValue id, {
+    required _i1.ColumnValueListBuilder<ArtistProfileUpdateTable> columnValues,
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.updateById<ArtistProfile>(
+      id,
+      columnValues: columnValues(ArtistProfile.t.updateTable),
+      transaction: transaction,
+    );
+  }
+
+  /// Updates all [ArtistProfile]s matching the [where] expression with the specified [columnValues].
+  /// Returns the list of updated rows.
+  Future<List<ArtistProfile>> updateWhere(
+    _i1.DatabaseSession session, {
+    required _i1.ColumnValueListBuilder<ArtistProfileUpdateTable> columnValues,
+    required _i1.WhereExpressionBuilder<ArtistProfileTable> where,
+    int? limit,
+    int? offset,
+    _i1.OrderByBuilder<ArtistProfileTable>? orderBy,
+    _i1.OrderByListBuilder<ArtistProfileTable>? orderByList,
+    bool orderDescending = false,
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.updateWhere<ArtistProfile>(
+      columnValues: columnValues(ArtistProfile.t.updateTable),
+      where: where(ArtistProfile.t),
+      limit: limit,
+      offset: offset,
+      orderBy: orderBy?.call(ArtistProfile.t),
+      orderByList: orderByList?.call(ArtistProfile.t),
+      orderDescending: orderDescending,
+      transaction: transaction,
+    );
+  }
+
+  /// Deletes all [ArtistProfile]s in the list and returns the deleted rows.
+  /// This is an atomic operation, meaning that if one of the rows fail to
+  /// be deleted, none of the rows will be deleted.
+  Future<List<ArtistProfile>> delete(
+    _i1.DatabaseSession session,
+    List<ArtistProfile> rows, {
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.delete<ArtistProfile>(
+      rows,
+      transaction: transaction,
+    );
+  }
+
+  /// Deletes a single [ArtistProfile].
+  Future<ArtistProfile> deleteRow(
+    _i1.DatabaseSession session,
+    ArtistProfile row, {
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.deleteRow<ArtistProfile>(
+      row,
+      transaction: transaction,
+    );
+  }
+
+  /// Deletes all rows matching the [where] expression.
+  Future<List<ArtistProfile>> deleteWhere(
+    _i1.DatabaseSession session, {
+    required _i1.WhereExpressionBuilder<ArtistProfileTable> where,
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.deleteWhere<ArtistProfile>(
+      where: where(ArtistProfile.t),
+      transaction: transaction,
+    );
+  }
+
+  /// Counts the number of rows matching the [where] expression. If omitted,
+  /// will return the count of all rows in the table.
+  Future<int> count(
+    _i1.DatabaseSession session, {
+    _i1.WhereExpressionBuilder<ArtistProfileTable>? where,
+    int? limit,
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.count<ArtistProfile>(
+      where: where?.call(ArtistProfile.t),
+      limit: limit,
+      transaction: transaction,
+    );
+  }
+
+  /// Acquires row-level locks on [ArtistProfile] rows matching the [where] expression.
+  Future<void> lockRows(
+    _i1.DatabaseSession session, {
+    required _i1.WhereExpressionBuilder<ArtistProfileTable> where,
+    required _i1.LockMode lockMode,
+    required _i1.Transaction transaction,
+    _i1.LockBehavior lockBehavior = _i1.LockBehavior.wait,
+  }) async {
+    return session.db.lockRows<ArtistProfile>(
+      where: where(ArtistProfile.t),
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
+      transaction: transaction,
+    );
+  }
+}

--- a/apps/octattoo/octattoo_server/lib/src/generated/customer/create_customer_result.dart
+++ b/apps/octattoo/octattoo_server/lib/src/generated/customer/create_customer_result.dart
@@ -1,0 +1,108 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+import '../customer/customer.dart' as _i2;
+import 'package:octattoo_server/src/generated/protocol.dart' as _i3;
+
+/// Result of creating a customer, includes potential duplicates.
+abstract class CreateCustomerResult
+    implements _i1.SerializableModel, _i1.ProtocolSerialization {
+  CreateCustomerResult._({
+    required this.customer,
+    required this.potentialDuplicates,
+  });
+
+  factory CreateCustomerResult({
+    required _i2.Customer customer,
+    required List<_i2.Customer> potentialDuplicates,
+  }) = _CreateCustomerResultImpl;
+
+  factory CreateCustomerResult.fromJson(
+    Map<String, dynamic> jsonSerialization,
+  ) {
+    return CreateCustomerResult(
+      customer: _i3.Protocol().deserialize<_i2.Customer>(
+        jsonSerialization['customer'],
+      ),
+      potentialDuplicates: _i3.Protocol().deserialize<List<_i2.Customer>>(
+        jsonSerialization['potentialDuplicates'],
+      ),
+    );
+  }
+
+  /// The newly created customer.
+  _i2.Customer customer;
+
+  /// Potential duplicate customers (non-blocking).
+  List<_i2.Customer> potentialDuplicates;
+
+  /// Returns a shallow copy of this [CreateCustomerResult]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  CreateCustomerResult copyWith({
+    _i2.Customer? customer,
+    List<_i2.Customer>? potentialDuplicates,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      '__className__': 'CreateCustomerResult',
+      'customer': customer.toJson(),
+      'potentialDuplicates': potentialDuplicates.toJson(
+        valueToJson: (v) => v.toJson(),
+      ),
+    };
+  }
+
+  @override
+  Map<String, dynamic> toJsonForProtocol() {
+    return {
+      '__className__': 'CreateCustomerResult',
+      'customer': customer.toJsonForProtocol(),
+      'potentialDuplicates': potentialDuplicates.toJson(
+        valueToJson: (v) => v.toJsonForProtocol(),
+      ),
+    };
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _CreateCustomerResultImpl extends CreateCustomerResult {
+  _CreateCustomerResultImpl({
+    required _i2.Customer customer,
+    required List<_i2.Customer> potentialDuplicates,
+  }) : super._(
+         customer: customer,
+         potentialDuplicates: potentialDuplicates,
+       );
+
+  /// Returns a shallow copy of this [CreateCustomerResult]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  CreateCustomerResult copyWith({
+    _i2.Customer? customer,
+    List<_i2.Customer>? potentialDuplicates,
+  }) {
+    return CreateCustomerResult(
+      customer: customer ?? this.customer.copyWith(),
+      potentialDuplicates:
+          potentialDuplicates ??
+          this.potentialDuplicates.map((e0) => e0.copyWith()).toList(),
+    );
+  }
+}

--- a/apps/octattoo/octattoo_server/lib/src/generated/customer/customer.dart
+++ b/apps/octattoo/octattoo_server/lib/src/generated/customer/customer.dart
@@ -1,0 +1,614 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+
+/// A person who receives tattoos. Scoped to a single Artist Profile.
+abstract class Customer
+    implements _i1.TableRow<_i1.UuidValue?>, _i1.ProtocolSerialization {
+  Customer._({
+    this.id,
+    required this.artistProfileId,
+    required this.name,
+    this.email,
+    this.phone,
+    this.notes,
+    this.createdAt,
+  });
+
+  factory Customer({
+    _i1.UuidValue? id,
+    required _i1.UuidValue artistProfileId,
+    required String name,
+    String? email,
+    String? phone,
+    String? notes,
+    DateTime? createdAt,
+  }) = _CustomerImpl;
+
+  factory Customer.fromJson(Map<String, dynamic> jsonSerialization) {
+    return Customer(
+      id: jsonSerialization['id'] == null
+          ? null
+          : _i1.UuidValueJsonExtension.fromJson(jsonSerialization['id']),
+      artistProfileId: _i1.UuidValueJsonExtension.fromJson(
+        jsonSerialization['artistProfileId'],
+      ),
+      name: jsonSerialization['name'] as String,
+      email: jsonSerialization['email'] as String?,
+      phone: jsonSerialization['phone'] as String?,
+      notes: jsonSerialization['notes'] as String?,
+      createdAt: jsonSerialization['createdAt'] == null
+          ? null
+          : _i1.DateTimeJsonExtension.fromJson(jsonSerialization['createdAt']),
+    );
+  }
+
+  static final t = CustomerTable();
+
+  static const db = CustomerRepository._();
+
+  @override
+  _i1.UuidValue? id;
+
+  /// The artist profile this customer belongs to.
+  _i1.UuidValue artistProfileId;
+
+  /// Display name.
+  String name;
+
+  /// Contact email (at least one of email/phone required).
+  String? email;
+
+  /// Contact phone (at least one of email/phone required).
+  String? phone;
+
+  /// Free-form notes.
+  String? notes;
+
+  /// When this customer was created.
+  DateTime? createdAt;
+
+  @override
+  _i1.Table<_i1.UuidValue?> get table => t;
+
+  /// Returns a shallow copy of this [Customer]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  Customer copyWith({
+    _i1.UuidValue? id,
+    _i1.UuidValue? artistProfileId,
+    String? name,
+    String? email,
+    String? phone,
+    String? notes,
+    DateTime? createdAt,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      '__className__': 'Customer',
+      if (id != null) 'id': id?.toJson(),
+      'artistProfileId': artistProfileId.toJson(),
+      'name': name,
+      if (email != null) 'email': email,
+      if (phone != null) 'phone': phone,
+      if (notes != null) 'notes': notes,
+      if (createdAt != null) 'createdAt': createdAt?.toJson(),
+    };
+  }
+
+  @override
+  Map<String, dynamic> toJsonForProtocol() {
+    return {
+      '__className__': 'Customer',
+      if (id != null) 'id': id?.toJson(),
+      'artistProfileId': artistProfileId.toJson(),
+      'name': name,
+      if (email != null) 'email': email,
+      if (phone != null) 'phone': phone,
+      if (notes != null) 'notes': notes,
+      if (createdAt != null) 'createdAt': createdAt?.toJson(),
+    };
+  }
+
+  static CustomerInclude include() {
+    return CustomerInclude._();
+  }
+
+  static CustomerIncludeList includeList({
+    _i1.WhereExpressionBuilder<CustomerTable>? where,
+    int? limit,
+    int? offset,
+    _i1.OrderByBuilder<CustomerTable>? orderBy,
+    bool orderDescending = false,
+    _i1.OrderByListBuilder<CustomerTable>? orderByList,
+    CustomerInclude? include,
+  }) {
+    return CustomerIncludeList._(
+      where: where,
+      limit: limit,
+      offset: offset,
+      orderBy: orderBy?.call(Customer.t),
+      orderDescending: orderDescending,
+      orderByList: orderByList?.call(Customer.t),
+      include: include,
+    );
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _Undefined {}
+
+class _CustomerImpl extends Customer {
+  _CustomerImpl({
+    _i1.UuidValue? id,
+    required _i1.UuidValue artistProfileId,
+    required String name,
+    String? email,
+    String? phone,
+    String? notes,
+    DateTime? createdAt,
+  }) : super._(
+         id: id,
+         artistProfileId: artistProfileId,
+         name: name,
+         email: email,
+         phone: phone,
+         notes: notes,
+         createdAt: createdAt,
+       );
+
+  /// Returns a shallow copy of this [Customer]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  Customer copyWith({
+    Object? id = _Undefined,
+    _i1.UuidValue? artistProfileId,
+    String? name,
+    Object? email = _Undefined,
+    Object? phone = _Undefined,
+    Object? notes = _Undefined,
+    Object? createdAt = _Undefined,
+  }) {
+    return Customer(
+      id: id is _i1.UuidValue? ? id : this.id,
+      artistProfileId: artistProfileId ?? this.artistProfileId,
+      name: name ?? this.name,
+      email: email is String? ? email : this.email,
+      phone: phone is String? ? phone : this.phone,
+      notes: notes is String? ? notes : this.notes,
+      createdAt: createdAt is DateTime? ? createdAt : this.createdAt,
+    );
+  }
+}
+
+class CustomerUpdateTable extends _i1.UpdateTable<CustomerTable> {
+  CustomerUpdateTable(super.table);
+
+  _i1.ColumnValue<_i1.UuidValue, _i1.UuidValue> artistProfileId(
+    _i1.UuidValue value,
+  ) => _i1.ColumnValue(
+    table.artistProfileId,
+    value,
+  );
+
+  _i1.ColumnValue<String, String> name(String value) => _i1.ColumnValue(
+    table.name,
+    value,
+  );
+
+  _i1.ColumnValue<String, String> email(String? value) => _i1.ColumnValue(
+    table.email,
+    value,
+  );
+
+  _i1.ColumnValue<String, String> phone(String? value) => _i1.ColumnValue(
+    table.phone,
+    value,
+  );
+
+  _i1.ColumnValue<String, String> notes(String? value) => _i1.ColumnValue(
+    table.notes,
+    value,
+  );
+
+  _i1.ColumnValue<DateTime, DateTime> createdAt(DateTime? value) =>
+      _i1.ColumnValue(
+        table.createdAt,
+        value,
+      );
+}
+
+class CustomerTable extends _i1.Table<_i1.UuidValue?> {
+  CustomerTable({super.tableRelation}) : super(tableName: 'customer') {
+    updateTable = CustomerUpdateTable(this);
+    artistProfileId = _i1.ColumnUuid(
+      'artistProfileId',
+      this,
+    );
+    name = _i1.ColumnString(
+      'name',
+      this,
+    );
+    email = _i1.ColumnString(
+      'email',
+      this,
+    );
+    phone = _i1.ColumnString(
+      'phone',
+      this,
+    );
+    notes = _i1.ColumnString(
+      'notes',
+      this,
+    );
+    createdAt = _i1.ColumnDateTime(
+      'createdAt',
+      this,
+      hasDefault: true,
+    );
+  }
+
+  late final CustomerUpdateTable updateTable;
+
+  /// The artist profile this customer belongs to.
+  late final _i1.ColumnUuid artistProfileId;
+
+  /// Display name.
+  late final _i1.ColumnString name;
+
+  /// Contact email (at least one of email/phone required).
+  late final _i1.ColumnString email;
+
+  /// Contact phone (at least one of email/phone required).
+  late final _i1.ColumnString phone;
+
+  /// Free-form notes.
+  late final _i1.ColumnString notes;
+
+  /// When this customer was created.
+  late final _i1.ColumnDateTime createdAt;
+
+  @override
+  List<_i1.Column> get columns => [
+    id,
+    artistProfileId,
+    name,
+    email,
+    phone,
+    notes,
+    createdAt,
+  ];
+}
+
+class CustomerInclude extends _i1.IncludeObject {
+  CustomerInclude._();
+
+  @override
+  Map<String, _i1.Include?> get includes => {};
+
+  @override
+  _i1.Table<_i1.UuidValue?> get table => Customer.t;
+}
+
+class CustomerIncludeList extends _i1.IncludeList {
+  CustomerIncludeList._({
+    _i1.WhereExpressionBuilder<CustomerTable>? where,
+    super.limit,
+    super.offset,
+    super.orderBy,
+    super.orderDescending,
+    super.orderByList,
+    super.include,
+  }) {
+    super.where = where?.call(Customer.t);
+  }
+
+  @override
+  Map<String, _i1.Include?> get includes => include?.includes ?? {};
+
+  @override
+  _i1.Table<_i1.UuidValue?> get table => Customer.t;
+}
+
+class CustomerRepository {
+  const CustomerRepository._();
+
+  /// Returns a list of [Customer]s matching the given query parameters.
+  ///
+  /// Use [where] to specify which items to include in the return value.
+  /// If none is specified, all items will be returned.
+  ///
+  /// To specify the order of the items use [orderBy] or [orderByList]
+  /// when sorting by multiple columns.
+  ///
+  /// The maximum number of items can be set by [limit]. If no limit is set,
+  /// all items matching the query will be returned.
+  ///
+  /// [offset] defines how many items to skip, after which [limit] (or all)
+  /// items are read from the database.
+  ///
+  /// ```dart
+  /// var persons = await Persons.db.find(
+  ///   session,
+  ///   where: (t) => t.lastName.equals('Jones'),
+  ///   orderBy: (t) => t.firstName,
+  ///   limit: 100,
+  /// );
+  /// ```
+  Future<List<Customer>> find(
+    _i1.DatabaseSession session, {
+    _i1.WhereExpressionBuilder<CustomerTable>? where,
+    int? limit,
+    int? offset,
+    _i1.OrderByBuilder<CustomerTable>? orderBy,
+    bool orderDescending = false,
+    _i1.OrderByListBuilder<CustomerTable>? orderByList,
+    _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
+  }) async {
+    return session.db.find<Customer>(
+      where: where?.call(Customer.t),
+      orderBy: orderBy?.call(Customer.t),
+      orderByList: orderByList?.call(Customer.t),
+      orderDescending: orderDescending,
+      limit: limit,
+      offset: offset,
+      transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
+    );
+  }
+
+  /// Returns the first matching [Customer] matching the given query parameters.
+  ///
+  /// Use [where] to specify which items to include in the return value.
+  /// If none is specified, all items will be returned.
+  ///
+  /// To specify the order use [orderBy] or [orderByList]
+  /// when sorting by multiple columns.
+  ///
+  /// [offset] defines how many items to skip, after which the next one will be picked.
+  ///
+  /// ```dart
+  /// var youngestPerson = await Persons.db.findFirstRow(
+  ///   session,
+  ///   where: (t) => t.lastName.equals('Jones'),
+  ///   orderBy: (t) => t.age,
+  /// );
+  /// ```
+  Future<Customer?> findFirstRow(
+    _i1.DatabaseSession session, {
+    _i1.WhereExpressionBuilder<CustomerTable>? where,
+    int? offset,
+    _i1.OrderByBuilder<CustomerTable>? orderBy,
+    bool orderDescending = false,
+    _i1.OrderByListBuilder<CustomerTable>? orderByList,
+    _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
+  }) async {
+    return session.db.findFirstRow<Customer>(
+      where: where?.call(Customer.t),
+      orderBy: orderBy?.call(Customer.t),
+      orderByList: orderByList?.call(Customer.t),
+      orderDescending: orderDescending,
+      offset: offset,
+      transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
+    );
+  }
+
+  /// Finds a single [Customer] by its [id] or null if no such row exists.
+  Future<Customer?> findById(
+    _i1.DatabaseSession session,
+    _i1.UuidValue id, {
+    _i1.Transaction? transaction,
+    _i1.LockMode? lockMode,
+    _i1.LockBehavior? lockBehavior,
+  }) async {
+    return session.db.findById<Customer>(
+      id,
+      transaction: transaction,
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
+    );
+  }
+
+  /// Inserts all [Customer]s in the list and returns the inserted rows.
+  ///
+  /// The returned [Customer]s will have their `id` fields set.
+  ///
+  /// This is an atomic operation, meaning that if one of the rows fails to
+  /// insert, none of the rows will be inserted.
+  ///
+  /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
+  /// rows are silently skipped, and only the successfully inserted rows are
+  /// returned.
+  Future<List<Customer>> insert(
+    _i1.DatabaseSession session,
+    List<Customer> rows, {
+    _i1.Transaction? transaction,
+    bool ignoreConflicts = false,
+  }) async {
+    return session.db.insert<Customer>(
+      rows,
+      transaction: transaction,
+      ignoreConflicts: ignoreConflicts,
+    );
+  }
+
+  /// Inserts a single [Customer] and returns the inserted row.
+  ///
+  /// The returned [Customer] will have its `id` field set.
+  Future<Customer> insertRow(
+    _i1.DatabaseSession session,
+    Customer row, {
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.insertRow<Customer>(
+      row,
+      transaction: transaction,
+    );
+  }
+
+  /// Updates all [Customer]s in the list and returns the updated rows. If
+  /// [columns] is provided, only those columns will be updated. Defaults to
+  /// all columns.
+  /// This is an atomic operation, meaning that if one of the rows fails to
+  /// update, none of the rows will be updated.
+  Future<List<Customer>> update(
+    _i1.DatabaseSession session,
+    List<Customer> rows, {
+    _i1.ColumnSelections<CustomerTable>? columns,
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.update<Customer>(
+      rows,
+      columns: columns?.call(Customer.t),
+      transaction: transaction,
+    );
+  }
+
+  /// Updates a single [Customer]. The row needs to have its id set.
+  /// Optionally, a list of [columns] can be provided to only update those
+  /// columns. Defaults to all columns.
+  Future<Customer> updateRow(
+    _i1.DatabaseSession session,
+    Customer row, {
+    _i1.ColumnSelections<CustomerTable>? columns,
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.updateRow<Customer>(
+      row,
+      columns: columns?.call(Customer.t),
+      transaction: transaction,
+    );
+  }
+
+  /// Updates a single [Customer] by its [id] with the specified [columnValues].
+  /// Returns the updated row or null if no row with the given id exists.
+  Future<Customer?> updateById(
+    _i1.DatabaseSession session,
+    _i1.UuidValue id, {
+    required _i1.ColumnValueListBuilder<CustomerUpdateTable> columnValues,
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.updateById<Customer>(
+      id,
+      columnValues: columnValues(Customer.t.updateTable),
+      transaction: transaction,
+    );
+  }
+
+  /// Updates all [Customer]s matching the [where] expression with the specified [columnValues].
+  /// Returns the list of updated rows.
+  Future<List<Customer>> updateWhere(
+    _i1.DatabaseSession session, {
+    required _i1.ColumnValueListBuilder<CustomerUpdateTable> columnValues,
+    required _i1.WhereExpressionBuilder<CustomerTable> where,
+    int? limit,
+    int? offset,
+    _i1.OrderByBuilder<CustomerTable>? orderBy,
+    _i1.OrderByListBuilder<CustomerTable>? orderByList,
+    bool orderDescending = false,
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.updateWhere<Customer>(
+      columnValues: columnValues(Customer.t.updateTable),
+      where: where(Customer.t),
+      limit: limit,
+      offset: offset,
+      orderBy: orderBy?.call(Customer.t),
+      orderByList: orderByList?.call(Customer.t),
+      orderDescending: orderDescending,
+      transaction: transaction,
+    );
+  }
+
+  /// Deletes all [Customer]s in the list and returns the deleted rows.
+  /// This is an atomic operation, meaning that if one of the rows fail to
+  /// be deleted, none of the rows will be deleted.
+  Future<List<Customer>> delete(
+    _i1.DatabaseSession session,
+    List<Customer> rows, {
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.delete<Customer>(
+      rows,
+      transaction: transaction,
+    );
+  }
+
+  /// Deletes a single [Customer].
+  Future<Customer> deleteRow(
+    _i1.DatabaseSession session,
+    Customer row, {
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.deleteRow<Customer>(
+      row,
+      transaction: transaction,
+    );
+  }
+
+  /// Deletes all rows matching the [where] expression.
+  Future<List<Customer>> deleteWhere(
+    _i1.DatabaseSession session, {
+    required _i1.WhereExpressionBuilder<CustomerTable> where,
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.deleteWhere<Customer>(
+      where: where(Customer.t),
+      transaction: transaction,
+    );
+  }
+
+  /// Counts the number of rows matching the [where] expression. If omitted,
+  /// will return the count of all rows in the table.
+  Future<int> count(
+    _i1.DatabaseSession session, {
+    _i1.WhereExpressionBuilder<CustomerTable>? where,
+    int? limit,
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.count<Customer>(
+      where: where?.call(Customer.t),
+      limit: limit,
+      transaction: transaction,
+    );
+  }
+
+  /// Acquires row-level locks on [Customer] rows matching the [where] expression.
+  Future<void> lockRows(
+    _i1.DatabaseSession session, {
+    required _i1.WhereExpressionBuilder<CustomerTable> where,
+    required _i1.LockMode lockMode,
+    required _i1.Transaction transaction,
+    _i1.LockBehavior lockBehavior = _i1.LockBehavior.wait,
+  }) async {
+    return session.db.lockRows<Customer>(
+      where: where(Customer.t),
+      lockMode: lockMode,
+      lockBehavior: lockBehavior,
+      transaction: transaction,
+    );
+  }
+}

--- a/apps/octattoo/octattoo_server/lib/src/generated/endpoints.dart
+++ b/apps/octattoo/octattoo_server/lib/src/generated/endpoints.dart
@@ -11,37 +11,61 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
-import '../auth/email_idp_endpoint.dart' as _i2;
-import '../auth/jwt_refresh_endpoint.dart' as _i3;
-import '../greetings/greeting_endpoint.dart' as _i4;
+import '../artist_profile/artist_profile_endpoint.dart' as _i2;
+import '../auth/email_idp_endpoint.dart' as _i3;
+import '../auth/jwt_refresh_endpoint.dart' as _i4;
+import '../greetings/greeting_endpoint.dart' as _i5;
 import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart'
-    as _i5;
-import 'package:serverpod_auth_core_server/serverpod_auth_core_server.dart'
     as _i6;
+import 'package:serverpod_auth_core_server/serverpod_auth_core_server.dart'
+    as _i7;
 
 class Endpoints extends _i1.EndpointDispatch {
   @override
   void initializeEndpoints(_i1.Server server) {
     var endpoints = <String, _i1.Endpoint>{
-      'emailIdp': _i2.EmailIdpEndpoint()
+      'artistProfile': _i2.ArtistProfileEndpoint()
+        ..initialize(
+          server,
+          'artistProfile',
+          null,
+        ),
+      'emailIdp': _i3.EmailIdpEndpoint()
         ..initialize(
           server,
           'emailIdp',
           null,
         ),
-      'jwtRefresh': _i3.JwtRefreshEndpoint()
+      'jwtRefresh': _i4.JwtRefreshEndpoint()
         ..initialize(
           server,
           'jwtRefresh',
           null,
         ),
-      'greeting': _i4.GreetingEndpoint()
+      'greeting': _i5.GreetingEndpoint()
         ..initialize(
           server,
           'greeting',
           null,
         ),
     };
+    connectors['artistProfile'] = _i1.EndpointConnector(
+      name: 'artistProfile',
+      endpoint: endpoints['artistProfile']!,
+      methodConnectors: {
+        'getMyProfileId': _i1.MethodConnector(
+          name: 'getMyProfileId',
+          params: {},
+          call:
+              (
+                _i1.Session session,
+                Map<String, dynamic> params,
+              ) async =>
+                  (endpoints['artistProfile'] as _i2.ArtistProfileEndpoint)
+                      .getMyProfileId(session),
+        ),
+      },
+    );
     connectors['emailIdp'] = _i1.EndpointConnector(
       name: 'emailIdp',
       endpoint: endpoints['emailIdp']!,
@@ -64,7 +88,7 @@ class Endpoints extends _i1.EndpointDispatch {
               (
                 _i1.Session session,
                 Map<String, dynamic> params,
-              ) async => (endpoints['emailIdp'] as _i2.EmailIdpEndpoint).login(
+              ) async => (endpoints['emailIdp'] as _i3.EmailIdpEndpoint).login(
                 session,
                 email: params['email'],
                 password: params['password'],
@@ -83,7 +107,7 @@ class Endpoints extends _i1.EndpointDispatch {
               (
                 _i1.Session session,
                 Map<String, dynamic> params,
-              ) async => (endpoints['emailIdp'] as _i2.EmailIdpEndpoint)
+              ) async => (endpoints['emailIdp'] as _i3.EmailIdpEndpoint)
                   .startRegistration(
                     session,
                     email: params['email'],
@@ -107,7 +131,7 @@ class Endpoints extends _i1.EndpointDispatch {
               (
                 _i1.Session session,
                 Map<String, dynamic> params,
-              ) async => (endpoints['emailIdp'] as _i2.EmailIdpEndpoint)
+              ) async => (endpoints['emailIdp'] as _i3.EmailIdpEndpoint)
                   .verifyRegistrationCode(
                     session,
                     accountRequestId: params['accountRequestId'],
@@ -132,7 +156,7 @@ class Endpoints extends _i1.EndpointDispatch {
               (
                 _i1.Session session,
                 Map<String, dynamic> params,
-              ) async => (endpoints['emailIdp'] as _i2.EmailIdpEndpoint)
+              ) async => (endpoints['emailIdp'] as _i3.EmailIdpEndpoint)
                   .finishRegistration(
                     session,
                     registrationToken: params['registrationToken'],
@@ -152,7 +176,7 @@ class Endpoints extends _i1.EndpointDispatch {
               (
                 _i1.Session session,
                 Map<String, dynamic> params,
-              ) async => (endpoints['emailIdp'] as _i2.EmailIdpEndpoint)
+              ) async => (endpoints['emailIdp'] as _i3.EmailIdpEndpoint)
                   .startPasswordReset(
                     session,
                     email: params['email'],
@@ -176,7 +200,7 @@ class Endpoints extends _i1.EndpointDispatch {
               (
                 _i1.Session session,
                 Map<String, dynamic> params,
-              ) async => (endpoints['emailIdp'] as _i2.EmailIdpEndpoint)
+              ) async => (endpoints['emailIdp'] as _i3.EmailIdpEndpoint)
                   .verifyPasswordResetCode(
                     session,
                     passwordResetRequestId: params['passwordResetRequestId'],
@@ -201,7 +225,7 @@ class Endpoints extends _i1.EndpointDispatch {
               (
                 _i1.Session session,
                 Map<String, dynamic> params,
-              ) async => (endpoints['emailIdp'] as _i2.EmailIdpEndpoint)
+              ) async => (endpoints['emailIdp'] as _i3.EmailIdpEndpoint)
                   .finishPasswordReset(
                     session,
                     finishPasswordResetToken:
@@ -216,7 +240,7 @@ class Endpoints extends _i1.EndpointDispatch {
               (
                 _i1.Session session,
                 Map<String, dynamic> params,
-              ) async => (endpoints['emailIdp'] as _i2.EmailIdpEndpoint)
+              ) async => (endpoints['emailIdp'] as _i3.EmailIdpEndpoint)
                   .hasAccount(session),
         ),
       },
@@ -238,7 +262,7 @@ class Endpoints extends _i1.EndpointDispatch {
               (
                 _i1.Session session,
                 Map<String, dynamic> params,
-              ) async => (endpoints['jwtRefresh'] as _i3.JwtRefreshEndpoint)
+              ) async => (endpoints['jwtRefresh'] as _i4.JwtRefreshEndpoint)
                   .refreshAccessToken(
                     session,
                     refreshToken: params['refreshToken'],
@@ -263,16 +287,16 @@ class Endpoints extends _i1.EndpointDispatch {
               (
                 _i1.Session session,
                 Map<String, dynamic> params,
-              ) async => (endpoints['greeting'] as _i4.GreetingEndpoint).hello(
+              ) async => (endpoints['greeting'] as _i5.GreetingEndpoint).hello(
                 session,
                 params['name'],
               ),
         ),
       },
     );
-    modules['serverpod_auth_idp'] = _i5.Endpoints()
+    modules['serverpod_auth_idp'] = _i6.Endpoints()
       ..initializeEndpoints(server);
-    modules['serverpod_auth_core'] = _i6.Endpoints()
+    modules['serverpod_auth_core'] = _i7.Endpoints()
       ..initializeEndpoints(server);
   }
 }

--- a/apps/octattoo/octattoo_server/lib/src/generated/endpoints.dart
+++ b/apps/octattoo/octattoo_server/lib/src/generated/endpoints.dart
@@ -14,11 +14,12 @@ import 'package:serverpod/serverpod.dart' as _i1;
 import '../artist_profile/artist_profile_endpoint.dart' as _i2;
 import '../auth/email_idp_endpoint.dart' as _i3;
 import '../auth/jwt_refresh_endpoint.dart' as _i4;
-import '../greetings/greeting_endpoint.dart' as _i5;
+import '../customer/customer_endpoint.dart' as _i5;
+import '../greetings/greeting_endpoint.dart' as _i6;
 import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart'
-    as _i6;
-import 'package:serverpod_auth_core_server/serverpod_auth_core_server.dart'
     as _i7;
+import 'package:serverpod_auth_core_server/serverpod_auth_core_server.dart'
+    as _i8;
 
 class Endpoints extends _i1.EndpointDispatch {
   @override
@@ -42,7 +43,13 @@ class Endpoints extends _i1.EndpointDispatch {
           'jwtRefresh',
           null,
         ),
-      'greeting': _i5.GreetingEndpoint()
+      'customer': _i5.CustomerEndpoint()
+        ..initialize(
+          server,
+          'customer',
+          null,
+        ),
+      'greeting': _i6.GreetingEndpoint()
         ..initialize(
           server,
           'greeting',
@@ -270,6 +277,149 @@ class Endpoints extends _i1.EndpointDispatch {
         ),
       },
     );
+    connectors['customer'] = _i1.EndpointConnector(
+      name: 'customer',
+      endpoint: endpoints['customer']!,
+      methodConnectors: {
+        'createCustomer': _i1.MethodConnector(
+          name: 'createCustomer',
+          params: {
+            'name': _i1.ParameterDescription(
+              name: 'name',
+              type: _i1.getType<String>(),
+              nullable: false,
+            ),
+            'email': _i1.ParameterDescription(
+              name: 'email',
+              type: _i1.getType<String?>(),
+              nullable: true,
+            ),
+            'phone': _i1.ParameterDescription(
+              name: 'phone',
+              type: _i1.getType<String?>(),
+              nullable: true,
+            ),
+            'notes': _i1.ParameterDescription(
+              name: 'notes',
+              type: _i1.getType<String?>(),
+              nullable: true,
+            ),
+          },
+          call:
+              (
+                _i1.Session session,
+                Map<String, dynamic> params,
+              ) async => (endpoints['customer'] as _i5.CustomerEndpoint)
+                  .createCustomer(
+                    session,
+                    name: params['name'],
+                    email: params['email'],
+                    phone: params['phone'],
+                    notes: params['notes'],
+                  ),
+        ),
+        'listCustomers': _i1.MethodConnector(
+          name: 'listCustomers',
+          params: {
+            'search': _i1.ParameterDescription(
+              name: 'search',
+              type: _i1.getType<String?>(),
+              nullable: true,
+            ),
+          },
+          call:
+              (
+                _i1.Session session,
+                Map<String, dynamic> params,
+              ) async =>
+                  (endpoints['customer'] as _i5.CustomerEndpoint).listCustomers(
+                    session,
+                    search: params['search'],
+                  ),
+        ),
+        'getCustomer': _i1.MethodConnector(
+          name: 'getCustomer',
+          params: {
+            'customerId': _i1.ParameterDescription(
+              name: 'customerId',
+              type: _i1.getType<_i1.UuidValue>(),
+              nullable: false,
+            ),
+          },
+          call:
+              (
+                _i1.Session session,
+                Map<String, dynamic> params,
+              ) async =>
+                  (endpoints['customer'] as _i5.CustomerEndpoint).getCustomer(
+                    session,
+                    params['customerId'],
+                  ),
+        ),
+        'updateCustomer': _i1.MethodConnector(
+          name: 'updateCustomer',
+          params: {
+            'customerId': _i1.ParameterDescription(
+              name: 'customerId',
+              type: _i1.getType<_i1.UuidValue>(),
+              nullable: false,
+            ),
+            'name': _i1.ParameterDescription(
+              name: 'name',
+              type: _i1.getType<String>(),
+              nullable: false,
+            ),
+            'email': _i1.ParameterDescription(
+              name: 'email',
+              type: _i1.getType<String?>(),
+              nullable: true,
+            ),
+            'phone': _i1.ParameterDescription(
+              name: 'phone',
+              type: _i1.getType<String?>(),
+              nullable: true,
+            ),
+            'notes': _i1.ParameterDescription(
+              name: 'notes',
+              type: _i1.getType<String?>(),
+              nullable: true,
+            ),
+          },
+          call:
+              (
+                _i1.Session session,
+                Map<String, dynamic> params,
+              ) async => (endpoints['customer'] as _i5.CustomerEndpoint)
+                  .updateCustomer(
+                    session,
+                    customerId: params['customerId'],
+                    name: params['name'],
+                    email: params['email'],
+                    phone: params['phone'],
+                    notes: params['notes'],
+                  ),
+        ),
+        'deleteCustomer': _i1.MethodConnector(
+          name: 'deleteCustomer',
+          params: {
+            'customerId': _i1.ParameterDescription(
+              name: 'customerId',
+              type: _i1.getType<_i1.UuidValue>(),
+              nullable: false,
+            ),
+          },
+          call:
+              (
+                _i1.Session session,
+                Map<String, dynamic> params,
+              ) async => (endpoints['customer'] as _i5.CustomerEndpoint)
+                  .deleteCustomer(
+                    session,
+                    params['customerId'],
+                  ),
+        ),
+      },
+    );
     connectors['greeting'] = _i1.EndpointConnector(
       name: 'greeting',
       endpoint: endpoints['greeting']!,
@@ -287,16 +437,16 @@ class Endpoints extends _i1.EndpointDispatch {
               (
                 _i1.Session session,
                 Map<String, dynamic> params,
-              ) async => (endpoints['greeting'] as _i5.GreetingEndpoint).hello(
+              ) async => (endpoints['greeting'] as _i6.GreetingEndpoint).hello(
                 session,
                 params['name'],
               ),
         ),
       },
     );
-    modules['serverpod_auth_idp'] = _i6.Endpoints()
+    modules['serverpod_auth_idp'] = _i7.Endpoints()
       ..initializeEndpoints(server);
-    modules['serverpod_auth_core'] = _i7.Endpoints()
+    modules['serverpod_auth_core'] = _i8.Endpoints()
       ..initializeEndpoints(server);
   }
 }

--- a/apps/octattoo/octattoo_server/lib/src/generated/protocol.dart
+++ b/apps/octattoo/octattoo_server/lib/src/generated/protocol.dart
@@ -16,7 +16,9 @@ import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart'
     as _i3;
 import 'package:serverpod_auth_core_server/serverpod_auth_core_server.dart'
     as _i4;
-import 'greetings/greeting.dart' as _i5;
+import 'artist_profile/artist_profile.dart' as _i5;
+import 'greetings/greeting.dart' as _i6;
+export 'artist_profile/artist_profile.dart';
 export 'greetings/greeting.dart';
 
 class Protocol extends _i1.SerializationManagerServer {
@@ -27,6 +29,63 @@ class Protocol extends _i1.SerializationManagerServer {
   static final Protocol _instance = Protocol._();
 
   static final List<_i2.TableDefinition> targetTableDefinitions = [
+    _i2.TableDefinition(
+      name: 'artist_profile',
+      dartName: 'ArtistProfile',
+      schema: 'public',
+      module: 'octattoo',
+      columns: [
+        _i2.ColumnDefinition(
+          name: 'id',
+          columnType: _i2.ColumnType.uuid,
+          isNullable: false,
+          dartType: 'UuidValue?',
+          columnDefault: 'gen_random_uuid_v7()',
+        ),
+        _i2.ColumnDefinition(
+          name: 'authUserId',
+          columnType: _i2.ColumnType.uuid,
+          isNullable: false,
+          dartType: 'UuidValue',
+        ),
+        _i2.ColumnDefinition(
+          name: 'name',
+          columnType: _i2.ColumnType.text,
+          isNullable: false,
+          dartType: 'String',
+        ),
+      ],
+      foreignKeys: [],
+      indexes: [
+        _i2.IndexDefinition(
+          indexName: 'artist_profile_pkey',
+          tableSpace: null,
+          elements: [
+            _i2.IndexElementDefinition(
+              type: _i2.IndexElementDefinitionType.column,
+              definition: 'id',
+            ),
+          ],
+          type: 'btree',
+          isUnique: true,
+          isPrimary: true,
+        ),
+        _i2.IndexDefinition(
+          indexName: 'artist_profile_auth_user_id_unique',
+          tableSpace: null,
+          elements: [
+            _i2.IndexElementDefinition(
+              type: _i2.IndexElementDefinitionType.column,
+              definition: 'authUserId',
+            ),
+          ],
+          type: 'btree',
+          isUnique: true,
+          isPrimary: false,
+        ),
+      ],
+      managed: true,
+    ),
     ..._i3.Protocol.targetTableDefinitions,
     ..._i4.Protocol.targetTableDefinitions,
     ..._i2.Protocol.targetTableDefinitions,
@@ -59,11 +118,17 @@ class Protocol extends _i1.SerializationManagerServer {
       }
     }
 
-    if (t == _i5.Greeting) {
-      return _i5.Greeting.fromJson(data) as T;
+    if (t == _i5.ArtistProfile) {
+      return _i5.ArtistProfile.fromJson(data) as T;
     }
-    if (t == _i1.getType<_i5.Greeting?>()) {
-      return (data != null ? _i5.Greeting.fromJson(data) : null) as T;
+    if (t == _i6.Greeting) {
+      return _i6.Greeting.fromJson(data) as T;
+    }
+    if (t == _i1.getType<_i5.ArtistProfile?>()) {
+      return (data != null ? _i5.ArtistProfile.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i6.Greeting?>()) {
+      return (data != null ? _i6.Greeting.fromJson(data) : null) as T;
     }
     try {
       return _i3.Protocol().deserialize<T>(data, t);
@@ -79,7 +144,8 @@ class Protocol extends _i1.SerializationManagerServer {
 
   static String? getClassNameForType(Type type) {
     return switch (type) {
-      _i5.Greeting => 'Greeting',
+      _i5.ArtistProfile => 'ArtistProfile',
+      _i6.Greeting => 'Greeting',
       _ => null,
     };
   }
@@ -94,7 +160,9 @@ class Protocol extends _i1.SerializationManagerServer {
     }
 
     switch (data) {
-      case _i5.Greeting():
+      case _i5.ArtistProfile():
+        return 'ArtistProfile';
+      case _i6.Greeting():
         return 'Greeting';
     }
     className = _i2.Protocol().getClassNameForObject(data);
@@ -118,8 +186,11 @@ class Protocol extends _i1.SerializationManagerServer {
     if (dataClassName is! String) {
       return super.deserializeByClassName(data);
     }
+    if (dataClassName == 'ArtistProfile') {
+      return deserialize<_i5.ArtistProfile>(data['data']);
+    }
     if (dataClassName == 'Greeting') {
-      return deserialize<_i5.Greeting>(data['data']);
+      return deserialize<_i6.Greeting>(data['data']);
     }
     if (dataClassName.startsWith('serverpod.')) {
       data['className'] = dataClassName.substring(10);
@@ -155,6 +226,10 @@ class Protocol extends _i1.SerializationManagerServer {
       if (table != null) {
         return table;
       }
+    }
+    switch (t) {
+      case _i5.ArtistProfile:
+        return _i5.ArtistProfile.t;
     }
     return null;
   }

--- a/apps/octattoo/octattoo_server/lib/src/generated/protocol.dart
+++ b/apps/octattoo/octattoo_server/lib/src/generated/protocol.dart
@@ -17,8 +17,13 @@ import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart'
 import 'package:serverpod_auth_core_server/serverpod_auth_core_server.dart'
     as _i4;
 import 'artist_profile/artist_profile.dart' as _i5;
-import 'greetings/greeting.dart' as _i6;
+import 'customer/create_customer_result.dart' as _i6;
+import 'customer/customer.dart' as _i7;
+import 'greetings/greeting.dart' as _i8;
+import 'package:octattoo_server/src/generated/customer/customer.dart' as _i9;
 export 'artist_profile/artist_profile.dart';
+export 'customer/create_customer_result.dart';
+export 'customer/customer.dart';
 export 'greetings/greeting.dart';
 
 class Protocol extends _i1.SerializationManagerServer {
@@ -86,6 +91,122 @@ class Protocol extends _i1.SerializationManagerServer {
       ],
       managed: true,
     ),
+    _i2.TableDefinition(
+      name: 'customer',
+      dartName: 'Customer',
+      schema: 'public',
+      module: 'octattoo',
+      columns: [
+        _i2.ColumnDefinition(
+          name: 'id',
+          columnType: _i2.ColumnType.uuid,
+          isNullable: false,
+          dartType: 'UuidValue?',
+          columnDefault: 'gen_random_uuid_v7()',
+        ),
+        _i2.ColumnDefinition(
+          name: 'artistProfileId',
+          columnType: _i2.ColumnType.uuid,
+          isNullable: false,
+          dartType: 'UuidValue',
+        ),
+        _i2.ColumnDefinition(
+          name: 'name',
+          columnType: _i2.ColumnType.text,
+          isNullable: false,
+          dartType: 'String',
+        ),
+        _i2.ColumnDefinition(
+          name: 'email',
+          columnType: _i2.ColumnType.text,
+          isNullable: true,
+          dartType: 'String?',
+        ),
+        _i2.ColumnDefinition(
+          name: 'phone',
+          columnType: _i2.ColumnType.text,
+          isNullable: true,
+          dartType: 'String?',
+        ),
+        _i2.ColumnDefinition(
+          name: 'notes',
+          columnType: _i2.ColumnType.text,
+          isNullable: true,
+          dartType: 'String?',
+        ),
+        _i2.ColumnDefinition(
+          name: 'createdAt',
+          columnType: _i2.ColumnType.timestampWithoutTimeZone,
+          isNullable: true,
+          dartType: 'DateTime?',
+          columnDefault: 'CURRENT_TIMESTAMP',
+        ),
+      ],
+      foreignKeys: [],
+      indexes: [
+        _i2.IndexDefinition(
+          indexName: 'customer_pkey',
+          tableSpace: null,
+          elements: [
+            _i2.IndexElementDefinition(
+              type: _i2.IndexElementDefinitionType.column,
+              definition: 'id',
+            ),
+          ],
+          type: 'btree',
+          isUnique: true,
+          isPrimary: true,
+        ),
+        _i2.IndexDefinition(
+          indexName: 'customer_artist_profile_id_idx',
+          tableSpace: null,
+          elements: [
+            _i2.IndexElementDefinition(
+              type: _i2.IndexElementDefinitionType.column,
+              definition: 'artistProfileId',
+            ),
+          ],
+          type: 'btree',
+          isUnique: false,
+          isPrimary: false,
+        ),
+        _i2.IndexDefinition(
+          indexName: 'customer_email_idx',
+          tableSpace: null,
+          elements: [
+            _i2.IndexElementDefinition(
+              type: _i2.IndexElementDefinitionType.column,
+              definition: 'artistProfileId',
+            ),
+            _i2.IndexElementDefinition(
+              type: _i2.IndexElementDefinitionType.column,
+              definition: 'email',
+            ),
+          ],
+          type: 'btree',
+          isUnique: false,
+          isPrimary: false,
+        ),
+        _i2.IndexDefinition(
+          indexName: 'customer_phone_idx',
+          tableSpace: null,
+          elements: [
+            _i2.IndexElementDefinition(
+              type: _i2.IndexElementDefinitionType.column,
+              definition: 'artistProfileId',
+            ),
+            _i2.IndexElementDefinition(
+              type: _i2.IndexElementDefinitionType.column,
+              definition: 'phone',
+            ),
+          ],
+          type: 'btree',
+          isUnique: false,
+          isPrimary: false,
+        ),
+      ],
+      managed: true,
+    ),
     ..._i3.Protocol.targetTableDefinitions,
     ..._i4.Protocol.targetTableDefinitions,
     ..._i2.Protocol.targetTableDefinitions,
@@ -121,14 +242,35 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i5.ArtistProfile) {
       return _i5.ArtistProfile.fromJson(data) as T;
     }
-    if (t == _i6.Greeting) {
-      return _i6.Greeting.fromJson(data) as T;
+    if (t == _i6.CreateCustomerResult) {
+      return _i6.CreateCustomerResult.fromJson(data) as T;
+    }
+    if (t == _i7.Customer) {
+      return _i7.Customer.fromJson(data) as T;
+    }
+    if (t == _i8.Greeting) {
+      return _i8.Greeting.fromJson(data) as T;
     }
     if (t == _i1.getType<_i5.ArtistProfile?>()) {
       return (data != null ? _i5.ArtistProfile.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i6.Greeting?>()) {
-      return (data != null ? _i6.Greeting.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i6.CreateCustomerResult?>()) {
+      return (data != null ? _i6.CreateCustomerResult.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i7.Customer?>()) {
+      return (data != null ? _i7.Customer.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i8.Greeting?>()) {
+      return (data != null ? _i8.Greeting.fromJson(data) : null) as T;
+    }
+    if (t == List<_i7.Customer>) {
+      return (data as List).map((e) => deserialize<_i7.Customer>(e)).toList()
+          as T;
+    }
+    if (t == List<_i9.Customer>) {
+      return (data as List).map((e) => deserialize<_i9.Customer>(e)).toList()
+          as T;
     }
     try {
       return _i3.Protocol().deserialize<T>(data, t);
@@ -145,7 +287,9 @@ class Protocol extends _i1.SerializationManagerServer {
   static String? getClassNameForType(Type type) {
     return switch (type) {
       _i5.ArtistProfile => 'ArtistProfile',
-      _i6.Greeting => 'Greeting',
+      _i6.CreateCustomerResult => 'CreateCustomerResult',
+      _i7.Customer => 'Customer',
+      _i8.Greeting => 'Greeting',
       _ => null,
     };
   }
@@ -162,7 +306,11 @@ class Protocol extends _i1.SerializationManagerServer {
     switch (data) {
       case _i5.ArtistProfile():
         return 'ArtistProfile';
-      case _i6.Greeting():
+      case _i6.CreateCustomerResult():
+        return 'CreateCustomerResult';
+      case _i7.Customer():
+        return 'Customer';
+      case _i8.Greeting():
         return 'Greeting';
     }
     className = _i2.Protocol().getClassNameForObject(data);
@@ -189,8 +337,14 @@ class Protocol extends _i1.SerializationManagerServer {
     if (dataClassName == 'ArtistProfile') {
       return deserialize<_i5.ArtistProfile>(data['data']);
     }
+    if (dataClassName == 'CreateCustomerResult') {
+      return deserialize<_i6.CreateCustomerResult>(data['data']);
+    }
+    if (dataClassName == 'Customer') {
+      return deserialize<_i7.Customer>(data['data']);
+    }
     if (dataClassName == 'Greeting') {
-      return deserialize<_i6.Greeting>(data['data']);
+      return deserialize<_i8.Greeting>(data['data']);
     }
     if (dataClassName.startsWith('serverpod.')) {
       data['className'] = dataClassName.substring(10);
@@ -230,6 +384,8 @@ class Protocol extends _i1.SerializationManagerServer {
     switch (t) {
       case _i5.ArtistProfile:
         return _i5.ArtistProfile.t;
+      case _i7.Customer:
+        return _i7.Customer.t;
     }
     return null;
   }

--- a/apps/octattoo/octattoo_server/lib/src/generated/protocol.yaml
+++ b/apps/octattoo/octattoo_server/lib/src/generated/protocol.yaml
@@ -1,3 +1,5 @@
+artistProfile:
+  - getMyProfileId:
 emailIdp:
   - login:
   - startRegistration:

--- a/apps/octattoo/octattoo_server/lib/src/generated/protocol.yaml
+++ b/apps/octattoo/octattoo_server/lib/src/generated/protocol.yaml
@@ -11,5 +11,11 @@ emailIdp:
   - hasAccount:
 jwtRefresh:
   - refreshAccessToken:
+customer:
+  - createCustomer:
+  - listCustomers:
+  - getCustomer:
+  - updateCustomer:
+  - deleteCustomer:
 greeting:
   - hello:

--- a/apps/octattoo/octattoo_server/migrations/20260429185117169/definition.json
+++ b/apps/octattoo/octattoo_server/migrations/20260429185117169/definition.json
@@ -1,0 +1,3233 @@
+{
+  "__className__": "serverpod.DatabaseDefinition",
+  "moduleName": "octattoo",
+  "tables": [
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "artist_profile",
+      "dartName": "ArtistProfile",
+      "module": "octattoo",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid_v7()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "authUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "name",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "artist_profile_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "artist_profile_auth_user_id_unique",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "authUserId"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_cloud_storage",
+      "dartName": "CloudStorageEntry",
+      "module": "serverpod",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_cloud_storage_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "storageId",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "path",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "addedTime",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "expiration",
+          "columnType": 4,
+          "isNullable": true,
+          "dartType": "DateTime?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "byteData",
+          "columnType": 5,
+          "isNullable": false,
+          "dartType": "dart:typed_data:ByteData"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "verified",
+          "columnType": 1,
+          "isNullable": false,
+          "dartType": "bool"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_cloud_storage_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_cloud_storage_path_idx",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "storageId"
+            },
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "path"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_cloud_storage_expiration",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "expiration"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_cloud_storage_direct_upload",
+      "dartName": "CloudStorageDirectUploadEntry",
+      "module": "serverpod",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_cloud_storage_direct_upload_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "storageId",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "path",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "expiration",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "authKey",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_cloud_storage_direct_upload_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_cloud_storage_direct_upload_storage_path",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "storageId"
+            },
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "path"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_future_call",
+      "dartName": "FutureCallEntry",
+      "module": "serverpod",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_future_call_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "name",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "time",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "serializedObject",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "serverId",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "identifier",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_future_call_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_future_call_time_idx",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "time"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_future_call_serverId_idx",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "serverId"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_future_call_identifier_idx",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "identifier"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_health_connection_info",
+      "dartName": "ServerHealthConnectionInfo",
+      "module": "serverpod",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_health_connection_info_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "serverId",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "timestamp",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "active",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "closing",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "idle",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "granularity",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_health_connection_info_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_health_connection_info_timestamp_idx",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "timestamp"
+            },
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "serverId"
+            },
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "granularity"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_health_metric",
+      "dartName": "ServerHealthMetric",
+      "module": "serverpod",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_health_metric_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "name",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "serverId",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "timestamp",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "isHealthy",
+          "columnType": 1,
+          "isNullable": false,
+          "dartType": "bool"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "value",
+          "columnType": 3,
+          "isNullable": false,
+          "dartType": "double"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "granularity",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_health_metric_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_health_metric_timestamp_idx",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "timestamp"
+            },
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "serverId"
+            },
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "name"
+            },
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "granularity"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_log",
+      "dartName": "LogEntry",
+      "module": "serverpod",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_log_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "sessionLogId",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "messageId",
+          "columnType": 6,
+          "isNullable": true,
+          "dartType": "int?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "reference",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "serverId",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "time",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "logLevel",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "protocol:LogLevel"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "message",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "error",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "stackTrace",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "order",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "__className__": "serverpod.ForeignKeyDefinition",
+          "constraintName": "serverpod_log_fk_0",
+          "columns": [
+            "sessionLogId"
+          ],
+          "referenceTable": "serverpod_session_log",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_log_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_log_sessionLogId_idx",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "sessionLogId"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_message_log",
+      "dartName": "MessageLogEntry",
+      "module": "serverpod",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_message_log_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "sessionLogId",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "serverId",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "messageId",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "endpoint",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "messageName",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "duration",
+          "columnType": 3,
+          "isNullable": false,
+          "dartType": "double"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "error",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "stackTrace",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "slow",
+          "columnType": 1,
+          "isNullable": false,
+          "dartType": "bool"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "order",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "__className__": "serverpod.ForeignKeyDefinition",
+          "constraintName": "serverpod_message_log_fk_0",
+          "columns": [
+            "sessionLogId"
+          ],
+          "referenceTable": "serverpod_session_log",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_message_log_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_method",
+      "dartName": "MethodInfo",
+      "module": "serverpod",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_method_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "endpoint",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "method",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_method_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_method_endpoint_method_idx",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "endpoint"
+            },
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "method"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_migrations",
+      "dartName": "DatabaseMigrationVersion",
+      "module": "serverpod",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_migrations_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "module",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "version",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "timestamp",
+          "columnType": 4,
+          "isNullable": true,
+          "dartType": "DateTime?"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_migrations_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_migrations_ids",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "module"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_query_log",
+      "dartName": "QueryLogEntry",
+      "module": "serverpod",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_query_log_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "serverId",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "sessionLogId",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "messageId",
+          "columnType": 6,
+          "isNullable": true,
+          "dartType": "int?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "query",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "duration",
+          "columnType": 3,
+          "isNullable": false,
+          "dartType": "double"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "numRows",
+          "columnType": 6,
+          "isNullable": true,
+          "dartType": "int?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "error",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "stackTrace",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "slow",
+          "columnType": 1,
+          "isNullable": false,
+          "dartType": "bool"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "order",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "__className__": "serverpod.ForeignKeyDefinition",
+          "constraintName": "serverpod_query_log_fk_0",
+          "columns": [
+            "sessionLogId"
+          ],
+          "referenceTable": "serverpod_session_log",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_query_log_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_query_log_sessionLogId_idx",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "sessionLogId"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_readwrite_test",
+      "dartName": "ReadWriteTestEntry",
+      "module": "serverpod",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_readwrite_test_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "number",
+          "columnType": 6,
+          "isNullable": false,
+          "dartType": "int"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_readwrite_test_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_runtime_settings",
+      "dartName": "RuntimeSettings",
+      "module": "serverpod",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_runtime_settings_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "logSettings",
+          "columnType": 8,
+          "isNullable": false,
+          "dartType": "protocol:LogSettings"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "logSettingsOverrides",
+          "columnType": 8,
+          "isNullable": false,
+          "dartType": "List<protocol:LogSettingsOverride>"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "logServiceCalls",
+          "columnType": 1,
+          "isNullable": false,
+          "dartType": "bool"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "logMalformedCalls",
+          "columnType": 1,
+          "isNullable": false,
+          "dartType": "bool"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_runtime_settings_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_session_log",
+      "dartName": "SessionLogEntry",
+      "module": "serverpod",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 6,
+          "isNullable": false,
+          "columnDefault": "nextval('serverpod_session_log_id_seq'::regclass)",
+          "dartType": "int?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "serverId",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "time",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "module",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "endpoint",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "method",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "duration",
+          "columnType": 3,
+          "isNullable": true,
+          "dartType": "double?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "numQueries",
+          "columnType": 6,
+          "isNullable": true,
+          "dartType": "int?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "slow",
+          "columnType": 1,
+          "isNullable": true,
+          "dartType": "bool?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "error",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "stackTrace",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "authenticatedUserId",
+          "columnType": 6,
+          "isNullable": true,
+          "dartType": "int?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "userId",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "isOpen",
+          "columnType": 1,
+          "isNullable": true,
+          "dartType": "bool?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "touched",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_session_log_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_session_log_serverid_idx",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "serverId"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_session_log_time_idx",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "time"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_session_log_touched_idx",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "touched"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_session_log_isopen_idx",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "isOpen"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_auth_idp_anonymous_account",
+      "dartName": "AnonymousAccount",
+      "module": "serverpod_auth_idp",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid_v7()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "authUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "createdAt",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "__className__": "serverpod.ForeignKeyDefinition",
+          "constraintName": "serverpod_auth_idp_anonymous_account_fk_0",
+          "columns": [
+            "authUserId"
+          ],
+          "referenceTable": "serverpod_auth_core_user",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_idp_anonymous_account_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_auth_idp_apple_account",
+      "dartName": "AppleAccount",
+      "module": "serverpod_auth_idp",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid_v7()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "userIdentifier",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "refreshToken",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "refreshTokenRequestedWithBundleIdentifier",
+          "columnType": 1,
+          "isNullable": false,
+          "dartType": "bool"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "lastRefreshedAt",
+          "columnType": 4,
+          "isNullable": false,
+          "columnDefault": "CURRENT_TIMESTAMP",
+          "dartType": "DateTime"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "authUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "createdAt",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "email",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "isEmailVerified",
+          "columnType": 1,
+          "isNullable": true,
+          "dartType": "bool?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "isPrivateEmail",
+          "columnType": 1,
+          "isNullable": true,
+          "dartType": "bool?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "firstName",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "lastName",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "__className__": "serverpod.ForeignKeyDefinition",
+          "constraintName": "serverpod_auth_idp_apple_account_fk_0",
+          "columns": [
+            "authUserId"
+          ],
+          "referenceTable": "serverpod_auth_core_user",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_idp_apple_account_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_apple_account_identifier",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "userIdentifier"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_auth_idp_email_account",
+      "dartName": "EmailAccount",
+      "module": "serverpod_auth_idp",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid_v7()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "authUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "createdAt",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "email",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "passwordHash",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "__className__": "serverpod.ForeignKeyDefinition",
+          "constraintName": "serverpod_auth_idp_email_account_fk_0",
+          "columns": [
+            "authUserId"
+          ],
+          "referenceTable": "serverpod_auth_core_user",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_idp_email_account_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_idp_email_account_email",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "email"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_auth_idp_email_account_password_reset_request",
+      "dartName": "EmailAccountPasswordResetRequest",
+      "module": "serverpod_auth_idp",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid_v7()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "emailAccountId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "createdAt",
+          "columnType": 4,
+          "isNullable": false,
+          "columnDefault": "CURRENT_TIMESTAMP",
+          "dartType": "DateTime"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "challengeId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "setPasswordChallengeId",
+          "columnType": 7,
+          "isNullable": true,
+          "dartType": "UuidValue?"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "__className__": "serverpod.ForeignKeyDefinition",
+          "constraintName": "serverpod_auth_idp_email_account_password_reset_request_fk_0",
+          "columns": [
+            "emailAccountId"
+          ],
+          "referenceTable": "serverpod_auth_idp_email_account",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        },
+        {
+          "__className__": "serverpod.ForeignKeyDefinition",
+          "constraintName": "serverpod_auth_idp_email_account_password_reset_request_fk_1",
+          "columns": [
+            "challengeId"
+          ],
+          "referenceTable": "serverpod_auth_idp_secret_challenge",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        },
+        {
+          "__className__": "serverpod.ForeignKeyDefinition",
+          "constraintName": "serverpod_auth_idp_email_account_password_reset_request_fk_2",
+          "columns": [
+            "setPasswordChallengeId"
+          ],
+          "referenceTable": "serverpod_auth_idp_secret_challenge",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_idp_email_account_password_reset_request_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_auth_idp_email_account_request",
+      "dartName": "EmailAccountRequest",
+      "module": "serverpod_auth_idp",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid_v7()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "createdAt",
+          "columnType": 4,
+          "isNullable": false,
+          "columnDefault": "CURRENT_TIMESTAMP",
+          "dartType": "DateTime"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "email",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "challengeId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "createAccountChallengeId",
+          "columnType": 7,
+          "isNullable": true,
+          "dartType": "UuidValue?"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "__className__": "serverpod.ForeignKeyDefinition",
+          "constraintName": "serverpod_auth_idp_email_account_request_fk_0",
+          "columns": [
+            "challengeId"
+          ],
+          "referenceTable": "serverpod_auth_idp_secret_challenge",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        },
+        {
+          "__className__": "serverpod.ForeignKeyDefinition",
+          "constraintName": "serverpod_auth_idp_email_account_request_fk_1",
+          "columns": [
+            "createAccountChallengeId"
+          ],
+          "referenceTable": "serverpod_auth_idp_secret_challenge",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_idp_email_account_request_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_idp_email_account_request_email",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "email"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_auth_idp_facebook_account",
+      "dartName": "FacebookAccount",
+      "module": "serverpod_auth_idp",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid_v7()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "authUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "createdAt",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "userIdentifier",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "email",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "fullName",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "firstName",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "lastName",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "__className__": "serverpod.ForeignKeyDefinition",
+          "constraintName": "serverpod_auth_idp_facebook_account_fk_0",
+          "columns": [
+            "authUserId"
+          ],
+          "referenceTable": "serverpod_auth_core_user",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_idp_facebook_account_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_facebook_account_user_identifier",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "userIdentifier"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_auth_idp_firebase_account",
+      "dartName": "FirebaseAccount",
+      "module": "serverpod_auth_idp",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid_v7()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "authUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "created",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "email",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "phone",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "userIdentifier",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "__className__": "serverpod.ForeignKeyDefinition",
+          "constraintName": "serverpod_auth_idp_firebase_account_fk_0",
+          "columns": [
+            "authUserId"
+          ],
+          "referenceTable": "serverpod_auth_core_user",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_idp_firebase_account_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_firebase_account_user_identifier",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "userIdentifier"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_auth_idp_github_account",
+      "dartName": "GitHubAccount",
+      "module": "serverpod_auth_idp",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid_v7()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "authUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "userIdentifier",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "email",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "created",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "__className__": "serverpod.ForeignKeyDefinition",
+          "constraintName": "serverpod_auth_idp_github_account_fk_0",
+          "columns": [
+            "authUserId"
+          ],
+          "referenceTable": "serverpod_auth_core_user",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_idp_github_account_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_github_account_user_identifier",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "userIdentifier"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_auth_idp_google_account",
+      "dartName": "GoogleAccount",
+      "module": "serverpod_auth_idp",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid_v7()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "authUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "created",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "email",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "userIdentifier",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "__className__": "serverpod.ForeignKeyDefinition",
+          "constraintName": "serverpod_auth_idp_google_account_fk_0",
+          "columns": [
+            "authUserId"
+          ],
+          "referenceTable": "serverpod_auth_core_user",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_idp_google_account_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_google_account_user_identifier",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "userIdentifier"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_auth_idp_microsoft_account",
+      "dartName": "MicrosoftAccount",
+      "module": "serverpod_auth_idp",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid_v7()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "authUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "userIdentifier",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "email",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "created",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "__className__": "serverpod.ForeignKeyDefinition",
+          "constraintName": "serverpod_auth_idp_microsoft_account_fk_0",
+          "columns": [
+            "authUserId"
+          ],
+          "referenceTable": "serverpod_auth_core_user",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_idp_microsoft_account_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_microsoft_account_user_identifier",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "userIdentifier"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_auth_idp_passkey_account",
+      "dartName": "PasskeyAccount",
+      "module": "serverpod_auth_idp",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid_v7()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "authUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "createdAt",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "keyId",
+          "columnType": 5,
+          "isNullable": false,
+          "dartType": "dart:typed_data:ByteData"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "keyIdBase64",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "clientDataJSON",
+          "columnType": 5,
+          "isNullable": false,
+          "dartType": "dart:typed_data:ByteData"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "attestationObject",
+          "columnType": 5,
+          "isNullable": false,
+          "dartType": "dart:typed_data:ByteData"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "originalChallenge",
+          "columnType": 5,
+          "isNullable": false,
+          "dartType": "dart:typed_data:ByteData"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "__className__": "serverpod.ForeignKeyDefinition",
+          "constraintName": "serverpod_auth_idp_passkey_account_fk_0",
+          "columns": [
+            "authUserId"
+          ],
+          "referenceTable": "serverpod_auth_core_user",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_idp_passkey_account_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_idp_passkey_account_key_id_base64",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "keyIdBase64"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_auth_idp_passkey_challenge",
+      "dartName": "PasskeyChallenge",
+      "module": "serverpod_auth_idp",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid_v7()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "createdAt",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "challenge",
+          "columnType": 5,
+          "isNullable": false,
+          "dartType": "dart:typed_data:ByteData"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_idp_passkey_challenge_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_auth_idp_rate_limited_request_attempt",
+      "dartName": "RateLimitedRequestAttempt",
+      "module": "serverpod_auth_idp",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid_v7()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "domain",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "source",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "nonce",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "ipAddress",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "attemptedAt",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "extraData",
+          "columnType": 8,
+          "isNullable": true,
+          "dartType": "Map<String,String>?"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_idp_rate_limited_request_attempt_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_idp_rate_limited_request_attempt_composite",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "domain"
+            },
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "source"
+            },
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "nonce"
+            },
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "attemptedAt"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_auth_idp_secret_challenge",
+      "dartName": "SecretChallenge",
+      "module": "serverpod_auth_idp",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid_v7()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "challengeCodeHash",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_idp_secret_challenge_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_auth_core_jwt_refresh_token",
+      "dartName": "RefreshToken",
+      "module": "serverpod_auth_core",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid_v7()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "authUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "scopeNames",
+          "columnType": 8,
+          "isNullable": false,
+          "dartType": "Set<String>"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "extraClaims",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "method",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "fixedSecret",
+          "columnType": 5,
+          "isNullable": false,
+          "dartType": "dart:typed_data:ByteData"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "rotatingSecretHash",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "lastUpdatedAt",
+          "columnType": 4,
+          "isNullable": false,
+          "columnDefault": "CURRENT_TIMESTAMP",
+          "dartType": "DateTime"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "createdAt",
+          "columnType": 4,
+          "isNullable": false,
+          "columnDefault": "CURRENT_TIMESTAMP",
+          "dartType": "DateTime"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "__className__": "serverpod.ForeignKeyDefinition",
+          "constraintName": "serverpod_auth_core_jwt_refresh_token_fk_0",
+          "columns": [
+            "authUserId"
+          ],
+          "referenceTable": "serverpod_auth_core_user",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_core_jwt_refresh_token_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_core_jwt_refresh_token_last_updated_at",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "lastUpdatedAt"
+            }
+          ],
+          "type": "btree",
+          "isUnique": false,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_auth_core_profile",
+      "dartName": "UserProfile",
+      "module": "serverpod_auth_core",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid_v7()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "authUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "userName",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "fullName",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "email",
+          "columnType": 0,
+          "isNullable": true,
+          "dartType": "String?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "createdAt",
+          "columnType": 4,
+          "isNullable": false,
+          "columnDefault": "CURRENT_TIMESTAMP",
+          "dartType": "DateTime"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "imageId",
+          "columnType": 7,
+          "isNullable": true,
+          "dartType": "UuidValue?"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "__className__": "serverpod.ForeignKeyDefinition",
+          "constraintName": "serverpod_auth_core_profile_fk_0",
+          "columns": [
+            "authUserId"
+          ],
+          "referenceTable": "serverpod_auth_core_user",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        },
+        {
+          "__className__": "serverpod.ForeignKeyDefinition",
+          "constraintName": "serverpod_auth_core_profile_fk_1",
+          "columns": [
+            "imageId"
+          ],
+          "referenceTable": "serverpod_auth_core_profile_image",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 3
+        }
+      ],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_core_profile_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_profile_user_profile_email_auth_user_id",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "authUserId"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_auth_core_profile_image",
+      "dartName": "UserProfileImage",
+      "module": "serverpod_auth_core",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid_v7()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "userProfileId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "createdAt",
+          "columnType": 4,
+          "isNullable": false,
+          "columnDefault": "CURRENT_TIMESTAMP",
+          "dartType": "DateTime"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "storageId",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "path",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "url",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "Uri"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "__className__": "serverpod.ForeignKeyDefinition",
+          "constraintName": "serverpod_auth_core_profile_image_fk_0",
+          "columns": [
+            "userProfileId"
+          ],
+          "referenceTable": "serverpod_auth_core_profile",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_core_profile_image_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_auth_core_session",
+      "dartName": "ServerSideSession",
+      "module": "serverpod_auth_core",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid_v7()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "authUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "scopeNames",
+          "columnType": 8,
+          "isNullable": false,
+          "dartType": "Set<String>"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "createdAt",
+          "columnType": 4,
+          "isNullable": false,
+          "columnDefault": "CURRENT_TIMESTAMP",
+          "dartType": "DateTime"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "lastUsedAt",
+          "columnType": 4,
+          "isNullable": false,
+          "columnDefault": "CURRENT_TIMESTAMP",
+          "dartType": "DateTime"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "expiresAt",
+          "columnType": 4,
+          "isNullable": true,
+          "dartType": "DateTime?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "expireAfterUnusedFor",
+          "columnType": 6,
+          "isNullable": true,
+          "dartType": "Duration?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "sessionKeyHash",
+          "columnType": 5,
+          "isNullable": false,
+          "dartType": "dart:typed_data:ByteData"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "sessionKeySalt",
+          "columnType": 5,
+          "isNullable": false,
+          "dartType": "dart:typed_data:ByteData"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "method",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [
+        {
+          "__className__": "serverpod.ForeignKeyDefinition",
+          "constraintName": "serverpod_auth_core_session_fk_0",
+          "columns": [
+            "authUserId"
+          ],
+          "referenceTable": "serverpod_auth_core_user",
+          "referenceTableSchema": "public",
+          "referenceColumns": [
+            "id"
+          ],
+          "onUpdate": 3,
+          "onDelete": 4
+        }
+      ],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_core_session_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        }
+      ],
+      "managed": true
+    },
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "serverpod_auth_core_user",
+      "dartName": "AuthUser",
+      "module": "serverpod_auth_core",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid_v7()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "createdAt",
+          "columnType": 4,
+          "isNullable": false,
+          "dartType": "DateTime"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "scopeNames",
+          "columnType": 8,
+          "isNullable": false,
+          "dartType": "Set<String>"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "blocked",
+          "columnType": 1,
+          "isNullable": false,
+          "dartType": "bool"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "serverpod_auth_core_user_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        }
+      ],
+      "managed": true
+    }
+  ],
+  "installedModules": [
+    {
+      "__className__": "serverpod.DatabaseMigrationVersion",
+      "module": "octattoo",
+      "version": "20260429185117169"
+    },
+    {
+      "__className__": "serverpod.DatabaseMigrationVersion",
+      "module": "serverpod",
+      "version": "20260129180959368"
+    },
+    {
+      "__className__": "serverpod.DatabaseMigrationVersion",
+      "module": "serverpod_auth_idp",
+      "version": "20260213194423028"
+    },
+    {
+      "__className__": "serverpod.DatabaseMigrationVersion",
+      "module": "serverpod_auth_core",
+      "version": "20260129181112269"
+    }
+  ],
+  "migrationApiVersion": 1
+}

--- a/apps/octattoo/octattoo_server/migrations/20260429185117169/definition.sql
+++ b/apps/octattoo/octattoo_server/migrations/20260429185117169/definition.sql
@@ -1,0 +1,755 @@
+BEGIN;
+
+--
+-- Function: gen_random_uuid_v7()
+-- Source: https://gist.github.com/kjmph/5bd772b2c2df145aa645b837da7eca74
+-- License: MIT (copyright notice included on the generator source code).
+--
+create or replace function gen_random_uuid_v7()
+returns uuid
+as $$
+begin
+  -- use random v4 uuid as starting point (which has the same variant we need)
+  -- then overlay timestamp
+  -- then set version 7 by flipping the 2 and 1 bit in the version 4 string
+  return encode(
+    set_bit(
+      set_bit(
+        overlay(uuid_send(gen_random_uuid())
+                placing substring(int8send(floor(extract(epoch from clock_timestamp()) * 1000)::bigint) from 3)
+                from 1 for 6
+        ),
+        52, 1
+      ),
+      53, 1
+    ),
+    'hex')::uuid;
+end
+$$
+language plpgsql
+volatile;
+
+--
+-- Class ArtistProfile as table artist_profile
+--
+CREATE TABLE "artist_profile" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid_v7(),
+    "authUserId" uuid NOT NULL,
+    "name" text NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "artist_profile_auth_user_id_unique" ON "artist_profile" USING btree ("authUserId");
+
+--
+-- Class CloudStorageEntry as table serverpod_cloud_storage
+--
+CREATE TABLE "serverpod_cloud_storage" (
+    "id" bigserial PRIMARY KEY,
+    "storageId" text NOT NULL,
+    "path" text NOT NULL,
+    "addedTime" timestamp without time zone NOT NULL,
+    "expiration" timestamp without time zone,
+    "byteData" bytea NOT NULL,
+    "verified" boolean NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_cloud_storage_path_idx" ON "serverpod_cloud_storage" USING btree ("storageId", "path");
+CREATE INDEX "serverpod_cloud_storage_expiration" ON "serverpod_cloud_storage" USING btree ("expiration");
+
+--
+-- Class CloudStorageDirectUploadEntry as table serverpod_cloud_storage_direct_upload
+--
+CREATE TABLE "serverpod_cloud_storage_direct_upload" (
+    "id" bigserial PRIMARY KEY,
+    "storageId" text NOT NULL,
+    "path" text NOT NULL,
+    "expiration" timestamp without time zone NOT NULL,
+    "authKey" text NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_cloud_storage_direct_upload_storage_path" ON "serverpod_cloud_storage_direct_upload" USING btree ("storageId", "path");
+
+--
+-- Class FutureCallEntry as table serverpod_future_call
+--
+CREATE TABLE "serverpod_future_call" (
+    "id" bigserial PRIMARY KEY,
+    "name" text NOT NULL,
+    "time" timestamp without time zone NOT NULL,
+    "serializedObject" text,
+    "serverId" text NOT NULL,
+    "identifier" text
+);
+
+-- Indexes
+CREATE INDEX "serverpod_future_call_time_idx" ON "serverpod_future_call" USING btree ("time");
+CREATE INDEX "serverpod_future_call_serverId_idx" ON "serverpod_future_call" USING btree ("serverId");
+CREATE INDEX "serverpod_future_call_identifier_idx" ON "serverpod_future_call" USING btree ("identifier");
+
+--
+-- Class ServerHealthConnectionInfo as table serverpod_health_connection_info
+--
+CREATE TABLE "serverpod_health_connection_info" (
+    "id" bigserial PRIMARY KEY,
+    "serverId" text NOT NULL,
+    "timestamp" timestamp without time zone NOT NULL,
+    "active" bigint NOT NULL,
+    "closing" bigint NOT NULL,
+    "idle" bigint NOT NULL,
+    "granularity" bigint NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_health_connection_info_timestamp_idx" ON "serverpod_health_connection_info" USING btree ("timestamp", "serverId", "granularity");
+
+--
+-- Class ServerHealthMetric as table serverpod_health_metric
+--
+CREATE TABLE "serverpod_health_metric" (
+    "id" bigserial PRIMARY KEY,
+    "name" text NOT NULL,
+    "serverId" text NOT NULL,
+    "timestamp" timestamp without time zone NOT NULL,
+    "isHealthy" boolean NOT NULL,
+    "value" double precision NOT NULL,
+    "granularity" bigint NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_health_metric_timestamp_idx" ON "serverpod_health_metric" USING btree ("timestamp", "serverId", "name", "granularity");
+
+--
+-- Class LogEntry as table serverpod_log
+--
+CREATE TABLE "serverpod_log" (
+    "id" bigserial PRIMARY KEY,
+    "sessionLogId" bigint NOT NULL,
+    "messageId" bigint,
+    "reference" text,
+    "serverId" text NOT NULL,
+    "time" timestamp without time zone NOT NULL,
+    "logLevel" bigint NOT NULL,
+    "message" text NOT NULL,
+    "error" text,
+    "stackTrace" text,
+    "order" bigint NOT NULL
+);
+
+-- Indexes
+CREATE INDEX "serverpod_log_sessionLogId_idx" ON "serverpod_log" USING btree ("sessionLogId");
+
+--
+-- Class MessageLogEntry as table serverpod_message_log
+--
+CREATE TABLE "serverpod_message_log" (
+    "id" bigserial PRIMARY KEY,
+    "sessionLogId" bigint NOT NULL,
+    "serverId" text NOT NULL,
+    "messageId" bigint NOT NULL,
+    "endpoint" text NOT NULL,
+    "messageName" text NOT NULL,
+    "duration" double precision NOT NULL,
+    "error" text,
+    "stackTrace" text,
+    "slow" boolean NOT NULL,
+    "order" bigint NOT NULL
+);
+
+--
+-- Class MethodInfo as table serverpod_method
+--
+CREATE TABLE "serverpod_method" (
+    "id" bigserial PRIMARY KEY,
+    "endpoint" text NOT NULL,
+    "method" text NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_method_endpoint_method_idx" ON "serverpod_method" USING btree ("endpoint", "method");
+
+--
+-- Class DatabaseMigrationVersion as table serverpod_migrations
+--
+CREATE TABLE "serverpod_migrations" (
+    "id" bigserial PRIMARY KEY,
+    "module" text NOT NULL,
+    "version" text NOT NULL,
+    "timestamp" timestamp without time zone
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_migrations_ids" ON "serverpod_migrations" USING btree ("module");
+
+--
+-- Class QueryLogEntry as table serverpod_query_log
+--
+CREATE TABLE "serverpod_query_log" (
+    "id" bigserial PRIMARY KEY,
+    "serverId" text NOT NULL,
+    "sessionLogId" bigint NOT NULL,
+    "messageId" bigint,
+    "query" text NOT NULL,
+    "duration" double precision NOT NULL,
+    "numRows" bigint,
+    "error" text,
+    "stackTrace" text,
+    "slow" boolean NOT NULL,
+    "order" bigint NOT NULL
+);
+
+-- Indexes
+CREATE INDEX "serverpod_query_log_sessionLogId_idx" ON "serverpod_query_log" USING btree ("sessionLogId");
+
+--
+-- Class ReadWriteTestEntry as table serverpod_readwrite_test
+--
+CREATE TABLE "serverpod_readwrite_test" (
+    "id" bigserial PRIMARY KEY,
+    "number" bigint NOT NULL
+);
+
+--
+-- Class RuntimeSettings as table serverpod_runtime_settings
+--
+CREATE TABLE "serverpod_runtime_settings" (
+    "id" bigserial PRIMARY KEY,
+    "logSettings" json NOT NULL,
+    "logSettingsOverrides" json NOT NULL,
+    "logServiceCalls" boolean NOT NULL,
+    "logMalformedCalls" boolean NOT NULL
+);
+
+--
+-- Class SessionLogEntry as table serverpod_session_log
+--
+CREATE TABLE "serverpod_session_log" (
+    "id" bigserial PRIMARY KEY,
+    "serverId" text NOT NULL,
+    "time" timestamp without time zone NOT NULL,
+    "module" text,
+    "endpoint" text,
+    "method" text,
+    "duration" double precision,
+    "numQueries" bigint,
+    "slow" boolean,
+    "error" text,
+    "stackTrace" text,
+    "authenticatedUserId" bigint,
+    "userId" text,
+    "isOpen" boolean,
+    "touched" timestamp without time zone NOT NULL
+);
+
+-- Indexes
+CREATE INDEX "serverpod_session_log_serverid_idx" ON "serverpod_session_log" USING btree ("serverId");
+CREATE INDEX "serverpod_session_log_time_idx" ON "serverpod_session_log" USING btree ("time");
+CREATE INDEX "serverpod_session_log_touched_idx" ON "serverpod_session_log" USING btree ("touched");
+CREATE INDEX "serverpod_session_log_isopen_idx" ON "serverpod_session_log" USING btree ("isOpen");
+
+--
+-- Class AnonymousAccount as table serverpod_auth_idp_anonymous_account
+--
+CREATE TABLE "serverpod_auth_idp_anonymous_account" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid_v7(),
+    "authUserId" uuid NOT NULL,
+    "createdAt" timestamp without time zone NOT NULL
+);
+
+--
+-- Class AppleAccount as table serverpod_auth_idp_apple_account
+--
+CREATE TABLE "serverpod_auth_idp_apple_account" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid_v7(),
+    "userIdentifier" text NOT NULL,
+    "refreshToken" text NOT NULL,
+    "refreshTokenRequestedWithBundleIdentifier" boolean NOT NULL,
+    "lastRefreshedAt" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "authUserId" uuid NOT NULL,
+    "createdAt" timestamp without time zone NOT NULL,
+    "email" text,
+    "isEmailVerified" boolean,
+    "isPrivateEmail" boolean,
+    "firstName" text,
+    "lastName" text
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_apple_account_identifier" ON "serverpod_auth_idp_apple_account" USING btree ("userIdentifier");
+
+--
+-- Class EmailAccount as table serverpod_auth_idp_email_account
+--
+CREATE TABLE "serverpod_auth_idp_email_account" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid_v7(),
+    "authUserId" uuid NOT NULL,
+    "createdAt" timestamp without time zone NOT NULL,
+    "email" text NOT NULL,
+    "passwordHash" text NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_idp_email_account_email" ON "serverpod_auth_idp_email_account" USING btree ("email");
+
+--
+-- Class EmailAccountPasswordResetRequest as table serverpod_auth_idp_email_account_password_reset_request
+--
+CREATE TABLE "serverpod_auth_idp_email_account_password_reset_request" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid_v7(),
+    "emailAccountId" uuid NOT NULL,
+    "createdAt" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "challengeId" uuid NOT NULL,
+    "setPasswordChallengeId" uuid
+);
+
+--
+-- Class EmailAccountRequest as table serverpod_auth_idp_email_account_request
+--
+CREATE TABLE "serverpod_auth_idp_email_account_request" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid_v7(),
+    "createdAt" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "email" text NOT NULL,
+    "challengeId" uuid NOT NULL,
+    "createAccountChallengeId" uuid
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_idp_email_account_request_email" ON "serverpod_auth_idp_email_account_request" USING btree ("email");
+
+--
+-- Class FacebookAccount as table serverpod_auth_idp_facebook_account
+--
+CREATE TABLE "serverpod_auth_idp_facebook_account" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid_v7(),
+    "authUserId" uuid NOT NULL,
+    "createdAt" timestamp without time zone NOT NULL,
+    "userIdentifier" text NOT NULL,
+    "email" text,
+    "fullName" text,
+    "firstName" text,
+    "lastName" text
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_facebook_account_user_identifier" ON "serverpod_auth_idp_facebook_account" USING btree ("userIdentifier");
+
+--
+-- Class FirebaseAccount as table serverpod_auth_idp_firebase_account
+--
+CREATE TABLE "serverpod_auth_idp_firebase_account" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid_v7(),
+    "authUserId" uuid NOT NULL,
+    "created" timestamp without time zone NOT NULL,
+    "email" text,
+    "phone" text,
+    "userIdentifier" text NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_firebase_account_user_identifier" ON "serverpod_auth_idp_firebase_account" USING btree ("userIdentifier");
+
+--
+-- Class GitHubAccount as table serverpod_auth_idp_github_account
+--
+CREATE TABLE "serverpod_auth_idp_github_account" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid_v7(),
+    "authUserId" uuid NOT NULL,
+    "userIdentifier" text NOT NULL,
+    "email" text,
+    "created" timestamp without time zone NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_github_account_user_identifier" ON "serverpod_auth_idp_github_account" USING btree ("userIdentifier");
+
+--
+-- Class GoogleAccount as table serverpod_auth_idp_google_account
+--
+CREATE TABLE "serverpod_auth_idp_google_account" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid_v7(),
+    "authUserId" uuid NOT NULL,
+    "created" timestamp without time zone NOT NULL,
+    "email" text NOT NULL,
+    "userIdentifier" text NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_google_account_user_identifier" ON "serverpod_auth_idp_google_account" USING btree ("userIdentifier");
+
+--
+-- Class MicrosoftAccount as table serverpod_auth_idp_microsoft_account
+--
+CREATE TABLE "serverpod_auth_idp_microsoft_account" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid_v7(),
+    "authUserId" uuid NOT NULL,
+    "userIdentifier" text NOT NULL,
+    "email" text,
+    "created" timestamp without time zone NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_microsoft_account_user_identifier" ON "serverpod_auth_idp_microsoft_account" USING btree ("userIdentifier");
+
+--
+-- Class PasskeyAccount as table serverpod_auth_idp_passkey_account
+--
+CREATE TABLE "serverpod_auth_idp_passkey_account" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid_v7(),
+    "authUserId" uuid NOT NULL,
+    "createdAt" timestamp without time zone NOT NULL,
+    "keyId" bytea NOT NULL,
+    "keyIdBase64" text NOT NULL,
+    "clientDataJSON" bytea NOT NULL,
+    "attestationObject" bytea NOT NULL,
+    "originalChallenge" bytea NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_idp_passkey_account_key_id_base64" ON "serverpod_auth_idp_passkey_account" USING btree ("keyIdBase64");
+
+--
+-- Class PasskeyChallenge as table serverpod_auth_idp_passkey_challenge
+--
+CREATE TABLE "serverpod_auth_idp_passkey_challenge" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid_v7(),
+    "createdAt" timestamp without time zone NOT NULL,
+    "challenge" bytea NOT NULL
+);
+
+--
+-- Class RateLimitedRequestAttempt as table serverpod_auth_idp_rate_limited_request_attempt
+--
+CREATE TABLE "serverpod_auth_idp_rate_limited_request_attempt" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid_v7(),
+    "domain" text NOT NULL,
+    "source" text NOT NULL,
+    "nonce" text NOT NULL,
+    "ipAddress" text,
+    "attemptedAt" timestamp without time zone NOT NULL,
+    "extraData" json
+);
+
+-- Indexes
+CREATE INDEX "serverpod_auth_idp_rate_limited_request_attempt_composite" ON "serverpod_auth_idp_rate_limited_request_attempt" USING btree ("domain", "source", "nonce", "attemptedAt");
+
+--
+-- Class SecretChallenge as table serverpod_auth_idp_secret_challenge
+--
+CREATE TABLE "serverpod_auth_idp_secret_challenge" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid_v7(),
+    "challengeCodeHash" text NOT NULL
+);
+
+--
+-- Class RefreshToken as table serverpod_auth_core_jwt_refresh_token
+--
+CREATE TABLE "serverpod_auth_core_jwt_refresh_token" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid_v7(),
+    "authUserId" uuid NOT NULL,
+    "scopeNames" json NOT NULL,
+    "extraClaims" text,
+    "method" text NOT NULL,
+    "fixedSecret" bytea NOT NULL,
+    "rotatingSecretHash" text NOT NULL,
+    "lastUpdatedAt" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Indexes
+CREATE INDEX "serverpod_auth_core_jwt_refresh_token_last_updated_at" ON "serverpod_auth_core_jwt_refresh_token" USING btree ("lastUpdatedAt");
+
+--
+-- Class UserProfile as table serverpod_auth_core_profile
+--
+CREATE TABLE "serverpod_auth_core_profile" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid_v7(),
+    "authUserId" uuid NOT NULL,
+    "userName" text,
+    "fullName" text,
+    "email" text,
+    "createdAt" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "imageId" uuid
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "serverpod_auth_profile_user_profile_email_auth_user_id" ON "serverpod_auth_core_profile" USING btree ("authUserId");
+
+--
+-- Class UserProfileImage as table serverpod_auth_core_profile_image
+--
+CREATE TABLE "serverpod_auth_core_profile_image" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid_v7(),
+    "userProfileId" uuid NOT NULL,
+    "createdAt" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "storageId" text NOT NULL,
+    "path" text NOT NULL,
+    "url" text NOT NULL
+);
+
+--
+-- Class ServerSideSession as table serverpod_auth_core_session
+--
+CREATE TABLE "serverpod_auth_core_session" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid_v7(),
+    "authUserId" uuid NOT NULL,
+    "scopeNames" json NOT NULL,
+    "createdAt" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastUsedAt" timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" timestamp without time zone,
+    "expireAfterUnusedFor" bigint,
+    "sessionKeyHash" bytea NOT NULL,
+    "sessionKeySalt" bytea NOT NULL,
+    "method" text NOT NULL
+);
+
+--
+-- Class AuthUser as table serverpod_auth_core_user
+--
+CREATE TABLE "serverpod_auth_core_user" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid_v7(),
+    "createdAt" timestamp without time zone NOT NULL,
+    "scopeNames" json NOT NULL,
+    "blocked" boolean NOT NULL
+);
+
+--
+-- Foreign relations for "serverpod_log" table
+--
+ALTER TABLE ONLY "serverpod_log"
+    ADD CONSTRAINT "serverpod_log_fk_0"
+    FOREIGN KEY("sessionLogId")
+    REFERENCES "serverpod_session_log"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_message_log" table
+--
+ALTER TABLE ONLY "serverpod_message_log"
+    ADD CONSTRAINT "serverpod_message_log_fk_0"
+    FOREIGN KEY("sessionLogId")
+    REFERENCES "serverpod_session_log"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_query_log" table
+--
+ALTER TABLE ONLY "serverpod_query_log"
+    ADD CONSTRAINT "serverpod_query_log_fk_0"
+    FOREIGN KEY("sessionLogId")
+    REFERENCES "serverpod_session_log"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_idp_anonymous_account" table
+--
+ALTER TABLE ONLY "serverpod_auth_idp_anonymous_account"
+    ADD CONSTRAINT "serverpod_auth_idp_anonymous_account_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_core_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_idp_apple_account" table
+--
+ALTER TABLE ONLY "serverpod_auth_idp_apple_account"
+    ADD CONSTRAINT "serverpod_auth_idp_apple_account_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_core_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_idp_email_account" table
+--
+ALTER TABLE ONLY "serverpod_auth_idp_email_account"
+    ADD CONSTRAINT "serverpod_auth_idp_email_account_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_core_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_idp_email_account_password_reset_request" table
+--
+ALTER TABLE ONLY "serverpod_auth_idp_email_account_password_reset_request"
+    ADD CONSTRAINT "serverpod_auth_idp_email_account_password_reset_request_fk_0"
+    FOREIGN KEY("emailAccountId")
+    REFERENCES "serverpod_auth_idp_email_account"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+ALTER TABLE ONLY "serverpod_auth_idp_email_account_password_reset_request"
+    ADD CONSTRAINT "serverpod_auth_idp_email_account_password_reset_request_fk_1"
+    FOREIGN KEY("challengeId")
+    REFERENCES "serverpod_auth_idp_secret_challenge"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+ALTER TABLE ONLY "serverpod_auth_idp_email_account_password_reset_request"
+    ADD CONSTRAINT "serverpod_auth_idp_email_account_password_reset_request_fk_2"
+    FOREIGN KEY("setPasswordChallengeId")
+    REFERENCES "serverpod_auth_idp_secret_challenge"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_idp_email_account_request" table
+--
+ALTER TABLE ONLY "serverpod_auth_idp_email_account_request"
+    ADD CONSTRAINT "serverpod_auth_idp_email_account_request_fk_0"
+    FOREIGN KEY("challengeId")
+    REFERENCES "serverpod_auth_idp_secret_challenge"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+ALTER TABLE ONLY "serverpod_auth_idp_email_account_request"
+    ADD CONSTRAINT "serverpod_auth_idp_email_account_request_fk_1"
+    FOREIGN KEY("createAccountChallengeId")
+    REFERENCES "serverpod_auth_idp_secret_challenge"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_idp_facebook_account" table
+--
+ALTER TABLE ONLY "serverpod_auth_idp_facebook_account"
+    ADD CONSTRAINT "serverpod_auth_idp_facebook_account_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_core_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_idp_firebase_account" table
+--
+ALTER TABLE ONLY "serverpod_auth_idp_firebase_account"
+    ADD CONSTRAINT "serverpod_auth_idp_firebase_account_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_core_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_idp_github_account" table
+--
+ALTER TABLE ONLY "serverpod_auth_idp_github_account"
+    ADD CONSTRAINT "serverpod_auth_idp_github_account_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_core_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_idp_google_account" table
+--
+ALTER TABLE ONLY "serverpod_auth_idp_google_account"
+    ADD CONSTRAINT "serverpod_auth_idp_google_account_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_core_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_idp_microsoft_account" table
+--
+ALTER TABLE ONLY "serverpod_auth_idp_microsoft_account"
+    ADD CONSTRAINT "serverpod_auth_idp_microsoft_account_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_core_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_idp_passkey_account" table
+--
+ALTER TABLE ONLY "serverpod_auth_idp_passkey_account"
+    ADD CONSTRAINT "serverpod_auth_idp_passkey_account_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_core_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_core_jwt_refresh_token" table
+--
+ALTER TABLE ONLY "serverpod_auth_core_jwt_refresh_token"
+    ADD CONSTRAINT "serverpod_auth_core_jwt_refresh_token_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_core_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_core_profile" table
+--
+ALTER TABLE ONLY "serverpod_auth_core_profile"
+    ADD CONSTRAINT "serverpod_auth_core_profile_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_core_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+ALTER TABLE ONLY "serverpod_auth_core_profile"
+    ADD CONSTRAINT "serverpod_auth_core_profile_fk_1"
+    FOREIGN KEY("imageId")
+    REFERENCES "serverpod_auth_core_profile_image"("id")
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_core_profile_image" table
+--
+ALTER TABLE ONLY "serverpod_auth_core_profile_image"
+    ADD CONSTRAINT "serverpod_auth_core_profile_image_fk_0"
+    FOREIGN KEY("userProfileId")
+    REFERENCES "serverpod_auth_core_profile"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+--
+-- Foreign relations for "serverpod_auth_core_session" table
+--
+ALTER TABLE ONLY "serverpod_auth_core_session"
+    ADD CONSTRAINT "serverpod_auth_core_session_fk_0"
+    FOREIGN KEY("authUserId")
+    REFERENCES "serverpod_auth_core_user"("id")
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
+
+
+--
+-- MIGRATION VERSION FOR octattoo
+--
+INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+    VALUES ('octattoo', '20260429185117169', now())
+    ON CONFLICT ("module")
+    DO UPDATE SET "version" = '20260429185117169', "timestamp" = now();
+
+--
+-- MIGRATION VERSION FOR serverpod
+--
+INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+    VALUES ('serverpod', '20260129180959368', now())
+    ON CONFLICT ("module")
+    DO UPDATE SET "version" = '20260129180959368', "timestamp" = now();
+
+--
+-- MIGRATION VERSION FOR serverpod_auth_idp
+--
+INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+    VALUES ('serverpod_auth_idp', '20260213194423028', now())
+    ON CONFLICT ("module")
+    DO UPDATE SET "version" = '20260213194423028', "timestamp" = now();
+
+--
+-- MIGRATION VERSION FOR serverpod_auth_core
+--
+INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+    VALUES ('serverpod_auth_core', '20260129181112269', now())
+    ON CONFLICT ("module")
+    DO UPDATE SET "version" = '20260129181112269', "timestamp" = now();
+
+
+COMMIT;

--- a/apps/octattoo/octattoo_server/migrations/20260429185117169/definition_project.json
+++ b/apps/octattoo/octattoo_server/migrations/20260429185117169/definition_project.json
@@ -1,0 +1,87 @@
+{
+  "__className__": "serverpod.DatabaseDefinition",
+  "moduleName": "octattoo",
+  "tables": [
+    {
+      "__className__": "serverpod.TableDefinition",
+      "name": "artist_profile",
+      "dartName": "ArtistProfile",
+      "module": "octattoo",
+      "schema": "public",
+      "columns": [
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "id",
+          "columnType": 7,
+          "isNullable": false,
+          "columnDefault": "gen_random_uuid_v7()",
+          "dartType": "UuidValue?"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "authUserId",
+          "columnType": 7,
+          "isNullable": false,
+          "dartType": "UuidValue"
+        },
+        {
+          "__className__": "serverpod.ColumnDefinition",
+          "name": "name",
+          "columnType": 0,
+          "isNullable": false,
+          "dartType": "String"
+        }
+      ],
+      "foreignKeys": [],
+      "indexes": [
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "artist_profile_pkey",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "id"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": true
+        },
+        {
+          "__className__": "serverpod.IndexDefinition",
+          "indexName": "artist_profile_auth_user_id_unique",
+          "elements": [
+            {
+              "__className__": "serverpod.IndexElementDefinition",
+              "type": 0,
+              "definition": "authUserId"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false
+        }
+      ],
+      "managed": true
+    }
+  ],
+  "installedModules": [
+    {
+      "__className__": "serverpod.DatabaseMigrationVersion",
+      "module": "serverpod",
+      "version": "20260129180959368"
+    },
+    {
+      "__className__": "serverpod.DatabaseMigrationVersion",
+      "module": "serverpod_auth_idp",
+      "version": "20260213194423028"
+    },
+    {
+      "__className__": "serverpod.DatabaseMigrationVersion",
+      "module": "serverpod_auth_core",
+      "version": "20260129181112269"
+    }
+  ],
+  "migrationApiVersion": 1
+}

--- a/apps/octattoo/octattoo_server/migrations/20260429185117169/migration.json
+++ b/apps/octattoo/octattoo_server/migrations/20260429185117169/migration.json
@@ -1,0 +1,74 @@
+{
+  "__className__": "serverpod.DatabaseMigration",
+  "actions": [
+    {
+      "__className__": "serverpod.DatabaseMigrationAction",
+      "type": "createTable",
+      "createTable": {
+        "__className__": "serverpod.TableDefinition",
+        "name": "artist_profile",
+        "dartName": "ArtistProfile",
+        "module": "octattoo",
+        "schema": "public",
+        "columns": [
+          {
+            "__className__": "serverpod.ColumnDefinition",
+            "name": "id",
+            "columnType": 7,
+            "isNullable": false,
+            "columnDefault": "gen_random_uuid_v7()",
+            "dartType": "UuidValue?"
+          },
+          {
+            "__className__": "serverpod.ColumnDefinition",
+            "name": "authUserId",
+            "columnType": 7,
+            "isNullable": false,
+            "dartType": "UuidValue"
+          },
+          {
+            "__className__": "serverpod.ColumnDefinition",
+            "name": "name",
+            "columnType": 0,
+            "isNullable": false,
+            "dartType": "String"
+          }
+        ],
+        "foreignKeys": [],
+        "indexes": [
+          {
+            "__className__": "serverpod.IndexDefinition",
+            "indexName": "artist_profile_pkey",
+            "elements": [
+              {
+                "__className__": "serverpod.IndexElementDefinition",
+                "type": 0,
+                "definition": "id"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": true
+          },
+          {
+            "__className__": "serverpod.IndexDefinition",
+            "indexName": "artist_profile_auth_user_id_unique",
+            "elements": [
+              {
+                "__className__": "serverpod.IndexElementDefinition",
+                "type": 0,
+                "definition": "authUserId"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": false
+          }
+        ],
+        "managed": true
+      }
+    }
+  ],
+  "warnings": [],
+  "migrationApiVersion": 1
+}

--- a/apps/octattoo/octattoo_server/migrations/20260429185117169/migration.sql
+++ b/apps/octattoo/octattoo_server/migrations/20260429185117169/migration.sql
@@ -1,0 +1,78 @@
+BEGIN;
+
+--
+-- Function: gen_random_uuid_v7()
+-- Source: https://gist.github.com/kjmph/5bd772b2c2df145aa645b837da7eca74
+-- License: MIT (copyright notice included on the generator source code).
+--
+create or replace function gen_random_uuid_v7()
+returns uuid
+as $$
+begin
+  -- use random v4 uuid as starting point (which has the same variant we need)
+  -- then overlay timestamp
+  -- then set version 7 by flipping the 2 and 1 bit in the version 4 string
+  return encode(
+    set_bit(
+      set_bit(
+        overlay(uuid_send(gen_random_uuid())
+                placing substring(int8send(floor(extract(epoch from clock_timestamp()) * 1000)::bigint) from 3)
+                from 1 for 6
+        ),
+        52, 1
+      ),
+      53, 1
+    ),
+    'hex')::uuid;
+end
+$$
+language plpgsql
+volatile;
+
+--
+-- ACTION CREATE TABLE
+--
+CREATE TABLE "artist_profile" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid_v7(),
+    "authUserId" uuid NOT NULL,
+    "name" text NOT NULL
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "artist_profile_auth_user_id_unique" ON "artist_profile" USING btree ("authUserId");
+
+
+--
+-- MIGRATION VERSION FOR octattoo
+--
+INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+    VALUES ('octattoo', '20260429185117169', now())
+    ON CONFLICT ("module")
+    DO UPDATE SET "version" = '20260429185117169', "timestamp" = now();
+
+--
+-- MIGRATION VERSION FOR serverpod
+--
+INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+    VALUES ('serverpod', '20260129180959368', now())
+    ON CONFLICT ("module")
+    DO UPDATE SET "version" = '20260129180959368', "timestamp" = now();
+
+--
+-- MIGRATION VERSION FOR serverpod_auth_idp
+--
+INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+    VALUES ('serverpod_auth_idp', '20260213194423028', now())
+    ON CONFLICT ("module")
+    DO UPDATE SET "version" = '20260213194423028', "timestamp" = now();
+
+--
+-- MIGRATION VERSION FOR serverpod_auth_core
+--
+INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+    VALUES ('serverpod_auth_core', '20260129181112269', now())
+    ON CONFLICT ("module")
+    DO UPDATE SET "version" = '20260129181112269', "timestamp" = now();
+
+
+COMMIT;

--- a/apps/octattoo/octattoo_server/migrations/migration_registry.txt
+++ b/apps/octattoo/octattoo_server/migrations/migration_registry.txt
@@ -5,3 +5,4 @@
 ### the conflict by removing and recreating the conflicting migration.
 
 20260429181050692
+20260429185117169

--- a/apps/octattoo/octattoo_server/test/integration/artist_profile_test.dart
+++ b/apps/octattoo/octattoo_server/test/integration/artist_profile_test.dart
@@ -17,8 +17,9 @@ void main() {
         ),
       );
 
-      final profileId =
-          await endpoints.artistProfile.getMyProfileId(authenticatedSession);
+      final profileId = await endpoints.artistProfile.getMyProfileId(
+        authenticatedSession,
+      );
       expect(profileId, isA<UuidValue>());
     });
 
@@ -34,10 +35,12 @@ void main() {
         ),
       );
 
-      final first =
-          await endpoints.artistProfile.getMyProfileId(authenticatedSession);
-      final second =
-          await endpoints.artistProfile.getMyProfileId(authenticatedSession);
+      final first = await endpoints.artistProfile.getMyProfileId(
+        authenticatedSession,
+      );
+      final second = await endpoints.artistProfile.getMyProfileId(
+        authenticatedSession,
+      );
       expect(first, equals(second));
     });
 

--- a/apps/octattoo/octattoo_server/test/integration/artist_profile_test.dart
+++ b/apps/octattoo/octattoo_server/test/integration/artist_profile_test.dart
@@ -1,0 +1,51 @@
+import 'package:test/test.dart';
+import 'package:serverpod/serverpod.dart';
+
+import 'test_tools/serverpod_test_tools.dart';
+
+void main() {
+  withServerpod('ArtistProfile', (sessionBuilder, endpoints) {
+    test('authenticated endpoint returns artistProfileId', () async {
+      final authUserId = UuidValue.fromString(
+        '550e8400-e29b-41d4-a716-446655440000',
+      );
+
+      final authenticatedSession = sessionBuilder.copyWith(
+        authentication: AuthenticationOverride.authenticationInfo(
+          authUserId.uuid,
+          {},
+        ),
+      );
+
+      final profileId =
+          await endpoints.artistProfile.getMyProfileId(authenticatedSession);
+      expect(profileId, isA<UuidValue>());
+    });
+
+    test('returns same profileId on subsequent calls', () async {
+      final authUserId = UuidValue.fromString(
+        '550e8400-e29b-41d4-a716-446655440001',
+      );
+
+      final authenticatedSession = sessionBuilder.copyWith(
+        authentication: AuthenticationOverride.authenticationInfo(
+          authUserId.uuid,
+          {},
+        ),
+      );
+
+      final first =
+          await endpoints.artistProfile.getMyProfileId(authenticatedSession);
+      final second =
+          await endpoints.artistProfile.getMyProfileId(authenticatedSession);
+      expect(first, equals(second));
+    });
+
+    test('rejects unauthenticated calls', () async {
+      expect(
+        () => endpoints.artistProfile.getMyProfileId(sessionBuilder),
+        throwsA(isA<ServerpodUnauthenticatedException>()),
+      );
+    });
+  });
+}

--- a/apps/octattoo/octattoo_server/test/integration/customer_test.dart
+++ b/apps/octattoo/octattoo_server/test/integration/customer_test.dart
@@ -1,0 +1,208 @@
+import 'package:test/test.dart';
+
+import 'test_tools/serverpod_test_tools.dart';
+
+void main() {
+  withServerpod('Customer CRUD', (sessionBuilder, endpoints) {
+    final authUserId1 = '550e8400-e29b-41d4-a716-446655440001';
+    final authUserId2 = '550e8400-e29b-41d4-a716-446655440002';
+
+    late TestSessionBuilder session1;
+    late TestSessionBuilder session2;
+
+    setUp(() {
+      session1 = sessionBuilder.copyWith(
+        authentication: AuthenticationOverride.authenticationInfo(
+          authUserId1,
+          {},
+        ),
+      );
+      session2 = sessionBuilder.copyWith(
+        authentication: AuthenticationOverride.authenticationInfo(
+          authUserId2,
+          {},
+        ),
+      );
+    });
+
+    test('creates a customer and returns it', () async {
+      // Ensure artist profile exists
+      await endpoints.artistProfile.getMyProfileId(session1);
+
+      final result = await endpoints.customer.createCustomer(
+        session1,
+        name: 'Alice',
+        email: 'alice@example.com',
+      );
+
+      expect(result.customer.name, 'Alice');
+      expect(result.customer.email, 'alice@example.com');
+      expect(result.customer.id, isNotNull);
+      expect(result.potentialDuplicates, isEmpty);
+    });
+
+    test('detects duplicate by email on create', () async {
+      await endpoints.artistProfile.getMyProfileId(session1);
+
+      await endpoints.customer.createCustomer(
+        session1,
+        name: 'Bob',
+        email: 'bob@example.com',
+      );
+
+      final result = await endpoints.customer.createCustomer(
+        session1,
+        name: 'Robert',
+        email: 'bob@example.com',
+      );
+
+      expect(result.customer.name, 'Robert');
+      expect(result.potentialDuplicates, hasLength(1));
+      expect(result.potentialDuplicates.first.name, 'Bob');
+    });
+
+    test('detects duplicate by phone on create', () async {
+      await endpoints.artistProfile.getMyProfileId(session1);
+
+      await endpoints.customer.createCustomer(
+        session1,
+        name: 'Charlie',
+        phone: '+33612345678',
+      );
+
+      final result = await endpoints.customer.createCustomer(
+        session1,
+        name: 'Charles',
+        phone: '+33612345678',
+      );
+
+      expect(result.potentialDuplicates, hasLength(1));
+      expect(result.potentialDuplicates.first.name, 'Charlie');
+    });
+
+    test('lists customers for current profile', () async {
+      await endpoints.artistProfile.getMyProfileId(session1);
+
+      await endpoints.customer.createCustomer(
+        session1,
+        name: 'Dave',
+        email: 'dave@example.com',
+      );
+
+      final list = await endpoints.customer.listCustomers(session1);
+      expect(list.any((c) => c.name == 'Dave'), isTrue);
+    });
+
+    test('search filters customers by name', () async {
+      await endpoints.artistProfile.getMyProfileId(session1);
+
+      await endpoints.customer.createCustomer(
+        session1,
+        name: 'Eve',
+        email: 'eve@example.com',
+      );
+      await endpoints.customer.createCustomer(
+        session1,
+        name: 'Frank',
+        phone: '+33600000001',
+      );
+
+      final results = await endpoints.customer.listCustomers(
+        session1,
+        search: 'Eve',
+      );
+      expect(results, hasLength(1));
+      expect(results.first.name, 'Eve');
+    });
+
+    test('updates a customer', () async {
+      await endpoints.artistProfile.getMyProfileId(session1);
+
+      final created = await endpoints.customer.createCustomer(
+        session1,
+        name: 'Grace',
+        email: 'grace@example.com',
+      );
+
+      final updated = await endpoints.customer.updateCustomer(
+        session1,
+        customerId: created.customer.id!,
+        name: 'Grace Updated',
+        email: 'grace.new@example.com',
+      );
+
+      expect(updated, isNotNull);
+      expect(updated!.name, 'Grace Updated');
+      expect(updated.email, 'grace.new@example.com');
+    });
+
+    test('deletes a customer', () async {
+      await endpoints.artistProfile.getMyProfileId(session1);
+
+      final created = await endpoints.customer.createCustomer(
+        session1,
+        name: 'Heidi',
+        email: 'heidi@example.com',
+      );
+
+      final deleted = await endpoints.customer.deleteCustomer(
+        session1,
+        created.customer.id!,
+      );
+      expect(deleted, isTrue);
+
+      final fetched = await endpoints.customer.getCustomer(
+        session1,
+        created.customer.id!,
+      );
+      expect(fetched, isNull);
+    });
+
+    test(
+      'cross-profile isolation: cannot see other profile customers',
+      () async {
+        await endpoints.artistProfile.getMyProfileId(session1);
+        await endpoints.artistProfile.getMyProfileId(session2);
+
+        await endpoints.customer.createCustomer(
+          session1,
+          name: 'Profile1Customer',
+          email: 'p1@example.com',
+        );
+
+        final list = await endpoints.customer.listCustomers(session2);
+        expect(list.where((c) => c.name == 'Profile1Customer'), isEmpty);
+      },
+    );
+
+    test(
+      'cross-profile isolation: cannot update other profile customer',
+      () async {
+        await endpoints.artistProfile.getMyProfileId(session1);
+        await endpoints.artistProfile.getMyProfileId(session2);
+
+        final created = await endpoints.customer.createCustomer(
+          session1,
+          name: 'Isolated',
+          email: 'isolated@example.com',
+        );
+
+        final result = await endpoints.customer.updateCustomer(
+          session2,
+          customerId: created.customer.id!,
+          name: 'Hacked',
+          email: 'hacked@example.com',
+        );
+
+        expect(result, isNull);
+      },
+    );
+
+    test('rejects unauthenticated calls', () async {
+      expect(
+        () => endpoints.customer.listCustomers(sessionBuilder),
+        throwsA(isA<ServerpodUnauthenticatedException>()),
+      );
+    });
+  });
+}

--- a/apps/octattoo/octattoo_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/apps/octattoo/octattoo_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -16,7 +16,10 @@ import 'package:serverpod/serverpod.dart' as _i2;
 import 'dart:async' as _i3;
 import 'package:serverpod_auth_core_server/serverpod_auth_core_server.dart'
     as _i4;
-import 'package:octattoo_server/src/generated/greetings/greeting.dart' as _i5;
+import 'package:octattoo_server/src/generated/customer/create_customer_result.dart'
+    as _i5;
+import 'package:octattoo_server/src/generated/customer/customer.dart' as _i6;
+import 'package:octattoo_server/src/generated/greetings/greeting.dart' as _i7;
 import 'package:octattoo_server/src/generated/protocol.dart';
 import 'package:octattoo_server/src/generated/endpoints.dart';
 export 'package:serverpod_test/serverpod_test_public_exports.dart';
@@ -137,6 +140,8 @@ class TestEndpoints {
 
   late final _JwtRefreshEndpoint jwtRefresh;
 
+  late final _CustomerEndpoint customer;
+
   late final _GreetingEndpoint greeting;
 }
 
@@ -156,6 +161,10 @@ class _InternalTestEndpoints extends TestEndpoints
       serializationManager,
     );
     jwtRefresh = _JwtRefreshEndpoint(
+      endpoints,
+      serializationManager,
+    );
+    customer = _CustomerEndpoint(
       endpoints,
       serializationManager,
     );
@@ -525,6 +534,190 @@ class _JwtRefreshEndpoint {
   }
 }
 
+class _CustomerEndpoint {
+  _CustomerEndpoint(
+    this._endpointDispatch,
+    this._serializationManager,
+  );
+
+  final _i2.EndpointDispatch _endpointDispatch;
+
+  final _i2.SerializationManager _serializationManager;
+
+  _i3.Future<_i5.CreateCustomerResult> createCustomer(
+    _i1.TestSessionBuilder sessionBuilder, {
+    required String name,
+    String? email,
+    String? phone,
+    String? notes,
+  }) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+            endpoint: 'customer',
+            method: 'createCustomer',
+          );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'customer',
+          methodName: 'createCustomer',
+          parameters: _i1.testObjectToJson({
+            'name': name,
+            'email': email,
+            'phone': phone,
+            'notes': notes,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue =
+            await (_localCallContext.method.call(
+                  _localUniqueSession,
+                  _localCallContext.arguments,
+                )
+                as _i3.Future<_i5.CreateCustomerResult>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
+
+  _i3.Future<List<_i6.Customer>> listCustomers(
+    _i1.TestSessionBuilder sessionBuilder, {
+    String? search,
+  }) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+            endpoint: 'customer',
+            method: 'listCustomers',
+          );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'customer',
+          methodName: 'listCustomers',
+          parameters: _i1.testObjectToJson({'search': search}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue =
+            await (_localCallContext.method.call(
+                  _localUniqueSession,
+                  _localCallContext.arguments,
+                )
+                as _i3.Future<List<_i6.Customer>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
+
+  _i3.Future<_i6.Customer?> getCustomer(
+    _i1.TestSessionBuilder sessionBuilder,
+    _i2.UuidValue customerId,
+  ) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+            endpoint: 'customer',
+            method: 'getCustomer',
+          );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'customer',
+          methodName: 'getCustomer',
+          parameters: _i1.testObjectToJson({'customerId': customerId}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue =
+            await (_localCallContext.method.call(
+                  _localUniqueSession,
+                  _localCallContext.arguments,
+                )
+                as _i3.Future<_i6.Customer?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
+
+  _i3.Future<_i6.Customer?> updateCustomer(
+    _i1.TestSessionBuilder sessionBuilder, {
+    required _i2.UuidValue customerId,
+    required String name,
+    String? email,
+    String? phone,
+    String? notes,
+  }) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+            endpoint: 'customer',
+            method: 'updateCustomer',
+          );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'customer',
+          methodName: 'updateCustomer',
+          parameters: _i1.testObjectToJson({
+            'customerId': customerId,
+            'name': name,
+            'email': email,
+            'phone': phone,
+            'notes': notes,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue =
+            await (_localCallContext.method.call(
+                  _localUniqueSession,
+                  _localCallContext.arguments,
+                )
+                as _i3.Future<_i6.Customer?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
+
+  _i3.Future<bool> deleteCustomer(
+    _i1.TestSessionBuilder sessionBuilder,
+    _i2.UuidValue customerId,
+  ) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+            endpoint: 'customer',
+            method: 'deleteCustomer',
+          );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'customer',
+          methodName: 'deleteCustomer',
+          parameters: _i1.testObjectToJson({'customerId': customerId}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue =
+            await (_localCallContext.method.call(
+                  _localUniqueSession,
+                  _localCallContext.arguments,
+                )
+                as _i3.Future<bool>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
+}
+
 class _GreetingEndpoint {
   _GreetingEndpoint(
     this._endpointDispatch,
@@ -535,7 +728,7 @@ class _GreetingEndpoint {
 
   final _i2.SerializationManager _serializationManager;
 
-  _i3.Future<_i5.Greeting> hello(
+  _i3.Future<_i7.Greeting> hello(
     _i1.TestSessionBuilder sessionBuilder,
     String name,
   ) async {
@@ -558,7 +751,7 @@ class _GreetingEndpoint {
                   _localUniqueSession,
                   _localCallContext.arguments,
                 )
-                as _i3.Future<_i5.Greeting>);
+                as _i3.Future<_i7.Greeting>);
         return _localReturnValue;
       } finally {
         await _localUniqueSession.close();

--- a/apps/octattoo/octattoo_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/apps/octattoo/octattoo_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -131,6 +131,8 @@ void withServerpod(
 }
 
 class TestEndpoints {
+  late final _ArtistProfileEndpoint artistProfile;
+
   late final _EmailIdpEndpoint emailIdp;
 
   late final _JwtRefreshEndpoint jwtRefresh;
@@ -145,6 +147,10 @@ class _InternalTestEndpoints extends TestEndpoints
     _i2.SerializationManager serializationManager,
     _i2.EndpointDispatch endpoints,
   ) {
+    artistProfile = _ArtistProfileEndpoint(
+      endpoints,
+      serializationManager,
+    );
     emailIdp = _EmailIdpEndpoint(
       endpoints,
       serializationManager,
@@ -157,6 +163,47 @@ class _InternalTestEndpoints extends TestEndpoints
       endpoints,
       serializationManager,
     );
+  }
+}
+
+class _ArtistProfileEndpoint {
+  _ArtistProfileEndpoint(
+    this._endpointDispatch,
+    this._serializationManager,
+  );
+
+  final _i2.EndpointDispatch _endpointDispatch;
+
+  final _i2.SerializationManager _serializationManager;
+
+  _i3.Future<_i2.UuidValue> getMyProfileId(
+    _i1.TestSessionBuilder sessionBuilder,
+  ) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+            endpoint: 'artistProfile',
+            method: 'getMyProfileId',
+          );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'artistProfile',
+          methodName: 'getMyProfileId',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue =
+            await (_localCallContext.method.call(
+                  _localUniqueSession,
+                  _localCallContext.arguments,
+                )
+                as _i3.Future<_i2.UuidValue>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
   }
 }
 

--- a/apps/octattoo/octattoo_server/test/unit/customer_endpoint_test.dart
+++ b/apps/octattoo/octattoo_server/test/unit/customer_endpoint_test.dart
@@ -1,0 +1,95 @@
+import 'package:test/test.dart';
+import 'package:serverpod/serverpod.dart';
+
+import 'package:octattoo_server/src/customer/customer_endpoint.dart';
+import 'package:octattoo_server/src/generated/protocol.dart';
+
+void main() {
+  group('CustomerEndpoint validation', () {
+    test('createCustomer throws when neither email nor phone provided', () {
+      final endpoint = CustomerEndpoint();
+      expect(
+        () => endpoint.validateContact(email: null, phone: null),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('validateContact passes with email only', () {
+      final endpoint = CustomerEndpoint();
+      expect(
+        () => endpoint.validateContact(email: 'a@b.com', phone: null),
+        returnsNormally,
+      );
+    });
+
+    test('validateContact passes with phone only', () {
+      final endpoint = CustomerEndpoint();
+      expect(
+        () => endpoint.validateContact(email: null, phone: '+33612345678'),
+        returnsNormally,
+      );
+    });
+  });
+
+  group('CustomerEndpoint duplicate detection', () {
+    test('findDuplicatesIn returns empty when no matches', () {
+      final endpoint = CustomerEndpoint();
+      final result = endpoint.findDuplicatesIn(
+        email: 'new@example.com',
+        phone: null,
+        existing: [],
+      );
+      expect(result, isEmpty);
+    });
+
+    test('findDuplicatesIn matches by email', () {
+      final endpoint = CustomerEndpoint();
+      final existing = [
+        _fakeCustomer(email: 'dup@example.com', phone: null),
+      ];
+      final result = endpoint.findDuplicatesIn(
+        email: 'dup@example.com',
+        phone: null,
+        existing: existing,
+      );
+      expect(result, hasLength(1));
+    });
+
+    test('findDuplicatesIn matches by phone', () {
+      final endpoint = CustomerEndpoint();
+      final existing = [
+        _fakeCustomer(email: null, phone: '+33612345678'),
+      ];
+      final result = endpoint.findDuplicatesIn(
+        email: null,
+        phone: '+33612345678',
+        existing: existing,
+      );
+      expect(result, hasLength(1));
+    });
+
+    test('findDuplicatesIn does not match different contact', () {
+      final endpoint = CustomerEndpoint();
+      final existing = [
+        _fakeCustomer(email: 'other@example.com', phone: '+33600000000'),
+      ];
+      final result = endpoint.findDuplicatesIn(
+        email: 'new@example.com',
+        phone: '+33611111111',
+        existing: existing,
+      );
+      expect(result, isEmpty);
+    });
+  });
+}
+
+Customer _fakeCustomer({String? email, String? phone}) {
+  return Customer(
+    artistProfileId: UuidValue.fromString(
+      '550e8400-e29b-41d4-a716-446655440000',
+    ),
+    name: 'Test',
+    email: email,
+    phone: phone,
+  );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,15 @@ melos:
       run: melos run test:dart && melos run test:flutter
 
     test:dart:
-      run: dart test
+      run: dart test --exclude-tags integration
+      exec:
+        concurrency: 1
+      packageFilters:
+        dirExists: test
+        flutter: false
+
+    test:integration:
+      run: dart test --tags integration
       exec:
         concurrency: 1
       packageFilters:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ melos:
       run: melos run test:dart && melos run test:flutter
 
     test:dart:
-      run: dart test --exclude-tags integration
+      run: dart test test/unit
       exec:
         concurrency: 1
       packageFilters:
@@ -36,7 +36,7 @@ melos:
         flutter: false
 
     test:integration:
-      run: dart test --tags integration
+      run: dart test test/integration
       exec:
         concurrency: 1
       packageFilters:


### PR DESCRIPTION
## Summary

Implements Customer CRUD with duplicate detection per Issue #4. Scoped by `artistProfileId` so each artist sees only their own clients.

## Changes

**Server:**
- `Customer` model (`spy.yaml`) with indexes on artistProfileId, email, phone
- `CustomerEndpoint`: create (with duplicate detection), list (with search), get, update, delete
- Validation: at least one of email/phone required
- Duplicate detection: on create, matches existing customers by email or phone within same profile (non-blocking — returns duplicates in response)

**Flutter:**
- `CustomerListScreen` with search bar and client-side filtering
- `CustomerDetailScreen` (name, contact, notes, relationship history placeholder)
- `CustomerFormScreen` with form validation
- `CustomerFormValidator` + `CustomerListViewModel`
- Wired into GoRouter (replaces Customers placeholder)

## What was tested

- `dart analyze` — 0 issues (server + flutter + client)
- `dart test --exclude-tags integration` (server) — 8/8 pass
- `flutter test` — 13/13 pass (8 new + 5 existing)
- `dart format` — clean
- Integration tests written (10 tests) for local DB runs

## Notes

- Based on `feat/3-identity-stub` — will rebase onto main after PR #35 merges
- UI screens are functional stubs (not wired to real API calls yet — endpoint integration comes with the full auth flow)

Closes #4